### PR TITLE
Use systemwide googletest instead of downloading it on the fly

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,39 +2,38 @@
 # Copyright (C) 2018 Peter Petrik (zilolv at gmail dot com)
 
 FIND_PACKAGE(Threads REQUIRED)
+FIND_PACKAGE(GTest)
 
-#########################################################################
-#########################################################################
-#########################################################################
-#########################################################################
-# https://crascit.com/2015/07/25/cmake-gtest/
+IF (NOT GTEST_FOUND)
+    # Download and unpack googletest at configure time
+    FILE(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download")
+    CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/GTestCMakeLists.in" "${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt")
+    EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download" )
+    EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" --build .
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download" )
 
-# Download and unpack googletest at configure time
-FILE(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download")
-CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/GTestCMakeLists.in" "${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt")
-EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download" )
-EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" --build .
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download" )
+    # Prevent GoogleTest from overriding our compiler/linker options
+    # when building with Visual Studio
+    SET(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-# Prevent GoogleTest from overriding our compiler/linker options
-# when building with Visual Studio
-SET(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    # Add googletest directly to our build. This adds
+    # the following targets: gtest, gtest_main, gmock
+    # and gmock_main
+    ADD_SUBDIRECTORY("${CMAKE_BINARY_DIR}/googletest-src"
+                     "${CMAKE_BINARY_DIR}/googletest-build"
+                     EXCLUDE_FROM_ALL)
+    # The gtest/gmock targets carry header search path
+    # dependencies automatically when using CMake 2.8.11 or
+    # later. Otherwise we have to add them here ourselves.
+    if(CMAKE_VERSION VERSION_LESS 2.8.11)
+        include_directories("${gtest_SOURCE_DIR}/include"
+                            "${gmock_SOURCE_DIR}/include")
+    endif()
+ELSE(NOT GTEST_FOUND)
+    include_directories(${GTEST_INCLUDE_DIR})
+ENDIF(NOT GTEST_FOUND)
 
-# Add googletest directly to our build. This adds
-# the following targets: gtest, gtest_main, gmock
-# and gmock_main
-ADD_SUBDIRECTORY("${CMAKE_BINARY_DIR}/googletest-src"
-                 "${CMAKE_BINARY_DIR}/googletest-build"
-                 EXCLUDE_FROM_ALL)
-
-# The gtest/gmock targets carry header search path
-# dependencies automatically when using CMake 2.8.11 or
-# later. Otherwise we have to add them here ourselves.
-if(CMAKE_VERSION VERSION_LESS 2.8.11)
-    include_directories("${gtest_SOURCE_DIR}/include"
-                        "${gmock_SOURCE_DIR}/include")
-endif()
 
 #########################################################################
 #########################################################################


### PR DESCRIPTION
Fixes #95, from https://marc.info/?l=openbsd-ports&m=155257655618650&w=2 - with that we can run tests on OpenBSD, and the infra doesnt complain about network access during build.