### PR TITLE
UGRID format : searching the CRS variable name in the X variable

### DIFF
--- a/mdal/frmts/mdal_ugrid.cpp
+++ b/mdal/frmts/mdal_ugrid.cpp
@@ -252,10 +252,15 @@ std::string MDAL::DriverUgrid::getCoordinateSystemVariableName()
   std::string coordinate_system_variable;
 
   // first try to get the coordinate system variable from grid definition
-  if ( mNcFile.hasArr( nodeZVariableName() ) )
+  std::vector<std::string> nodeVariablesName = MDAL::split( mNcFile.getAttrStr( mMesh2dName, "node_coordinates" ), ' ' );
+  if ( nodeVariablesName.size() > 1 )
   {
-    coordinate_system_variable = mNcFile.getAttrStr( nodeZVariableName(), "grid_mapping" );
+    if ( mNcFile.hasArr( nodeVariablesName[0] ) )
+    {
+      coordinate_system_variable = mNcFile.getAttrStr( nodeVariablesName[0], "grid_mapping" );
+    }
   }
+
 
   // if automatic discovery fails, try to check some hardcoded common variables that store projection
   if ( coordinate_system_variable.empty() )

--- a/tests/test_ugrid.cpp
+++ b/tests/test_ugrid.cpp
@@ -262,6 +262,9 @@ TEST( MeshUgridTest, DFlow12RivierGridClm )
   double time = MDAL_D_time( ds );
   EXPECT_DOUBLE_EQ( 183.5, time );
 
+  std::string crs = MDAL_M_projection( m );
+  EXPECT_EQ( "EPSG:28992", crs );
+
   MDAL_CloseMesh( m );
 }
 
@@ -379,6 +382,9 @@ TEST( MeshUgridTest, DFlow12RivierGridMap )
   MDAL_D_minimumMaximum( ds, &min, &max );
   EXPECT_DOUBLE_EQ( 0, min );
   EXPECT_DOUBLE_EQ( 0.66413616798770714, max );
+
+  std::string crs = MDAL_M_projection( m );
+  EXPECT_EQ( "EPSG:28992", crs );
 
   MDAL_CloseMesh( m );
 }


### PR DESCRIPTION
Hello,

The coordinate system variable name was searched in the Z node variable name. As this variable is no required,  it will be better to search in the X variable name (or Y variable name).

I have added code in the UGRID tests for CRS.