### PR TITLE
Fix TUFLOW-FV bugs with maximum and projection

### DIFF
--- a/mdal/frmts/mdal_cf.cpp
+++ b/mdal/frmts/mdal_cf.cpp
@@ -313,10 +313,23 @@ bool MDAL::DriverCF::canReadMesh( const std::string &uri )
 void MDAL::DriverCF::setProjection( MDAL::Mesh *mesh )
 {
   std::string coordinate_system_variable = getCoordinateSystemVariableName();
+  // not present
+  if ( coordinate_system_variable.empty() )
+  {
+    return;
+  }
 
+  // in file
+  if ( MDAL::startsWith( coordinate_system_variable, "file://" ) )
+  {
+    const std::string filename = MDAL::replace( coordinate_system_variable, "file://", "" );
+    mesh->setSourceCrsFromPrjFile( filename );
+    return;
+  }
+
+  // in NetCDF attribute
   try
   {
-
     if ( !coordinate_system_variable.empty() )
     {
       std::string wkt = mNcFile->getAttrStr( coordinate_system_variable, "wkt" );
@@ -335,7 +348,6 @@ void MDAL::DriverCF::setProjection( MDAL::Mesh *mesh )
         {
           mesh->setSourceCrs( epsg_code );
         }
-
       }
       else
       {

--- a/mdal/frmts/mdal_cf.cpp
+++ b/mdal/frmts/mdal_cf.cpp
@@ -64,31 +64,34 @@ MDAL::cfdataset_info_map MDAL::DriverCF::parseDatasetGroupInfo()
 
       int dimid;
       size_t nTimesteps;
-      bool time_is_first_dimension = true;
+      CFDatasetGroupInfo::TimeLocation timeLocation;
 
       if ( ndims == 1 )
       {
         nTimesteps = 1;
         dimid = dimids[0];
+        timeLocation = CFDatasetGroupInfo::NoTimeDimension;
       }
       else
       {
-        /*UGRID convention says "The order of dimensions on a data variable is arbitrary",
-        *So time dimension is not necessary the first dimension, event if the convention recommands it.
-        *And prevent that any of the the two dimensions is not time dimension
-        */
+        /*
+         * UGRID convention says "The order of dimensions on a data variable is arbitrary",
+         * So time dimension is not necessary the first dimension, event if the convention recommands it.
+         * And prevent that any of the the two dimensions is not time dimension
+         */
         if ( mDimensions.type( dimids[0] ) == CFDimensions::Time )
         {
-          time_is_first_dimension = true;
+          timeLocation = CFDatasetGroupInfo::TimeDimensionFirst;
           dimid = dimids[1];
         }
         else if ( mDimensions.type( dimids[1] ) == CFDimensions::Time )
         {
-          time_is_first_dimension = false;
+          timeLocation = CFDatasetGroupInfo::TimeDimensionLast;
           dimid = dimids[0];
         }
         else
         {
+          // unknown array
           continue;
         }
 
@@ -134,7 +137,7 @@ MDAL::cfdataset_info_map MDAL::DriverCF::parseDatasetGroupInfo()
         dsInfo.outputType = mDimensions.type( dimid );
         dsInfo.name = name;
         dsInfo.nValues = mDimensions.size( mDimensions.type( dimid ) );
-        dsInfo.time_first_dim = time_is_first_dimension;
+        dsInfo.timeLocation = timeLocation;
         dsinfo_map[name] = dsInfo;
       }
     }
@@ -263,7 +266,7 @@ std::shared_ptr<MDAL::Dataset> MDAL::DriverCF::create2DDataset( std::shared_ptr<
         fill_val_y,
         dsi.ncid_x,
         dsi.ncid_y,
-        dsi.time_first_dim,
+        dsi.timeLocation,
         dsi.nTimesteps,
         dsi.nValues,
         ts,
@@ -445,14 +448,14 @@ bool MDAL::CFDimensions::isDatasetType( MDAL::CFDimensions::Type type ) const
 //////////////////////////////////////////////////////////////////////////////////////
 MDAL::CFDataset2D::CFDataset2D( MDAL::DatasetGroup *parent,
                                 double fill_val_x, double fill_val_y,
-                                int ncid_x, int ncid_y, bool time_first_dim,
+                                int ncid_x, int ncid_y, CFDatasetGroupInfo::TimeLocation timeLocation,
                                 size_t timesteps, size_t values, size_t ts, std::shared_ptr<NetCDFFile> ncFile )
   : Dataset2D( parent )
   , mFillValX( fill_val_x )
   , mFillValY( fill_val_y )
   , mNcidX( ncid_x )
   , mNcidY( ncid_y )
-  , mTimeFirstDim( time_first_dim )
+  , mTimeLocation( timeLocation )
   , mTimesteps( timesteps )
   , mValues( values )
   , mTs( ts )
@@ -471,19 +474,32 @@ size_t MDAL::CFDataset2D::scalarData( size_t indexStart, size_t count, double *b
     return 0;
 
   size_t copyValues = std::min( mValues - indexStart, count );
+  std::vector<double> values_x;
 
-  size_t start_dim1 = mTimeFirstDim ?  mTs : indexStart;
-  size_t start_dim2 = mTimeFirstDim ?  indexStart : mTs;
-  size_t count_dim1 = mTimeFirstDim ?  1 : copyValues;
-  size_t count_dim2 = mTimeFirstDim ?  copyValues : 1;
+  if ( mTimeLocation == CFDatasetGroupInfo::NoTimeDimension )
+  {
+    values_x = mNcFile->readDoubleArr(
+                 mNcidX,
+                 indexStart,
+                 copyValues
+               );
+  }
+  else
+  {
+    bool timeFirstDim = mTimeLocation == CFDatasetGroupInfo::TimeDimensionFirst;
+    size_t start_dim1 = timeFirstDim ?  mTs : indexStart;
+    size_t start_dim2 = timeFirstDim ?  indexStart : mTs;
+    size_t count_dim1 = timeFirstDim ?  1 : copyValues;
+    size_t count_dim2 = timeFirstDim ?  copyValues : 1;
 
-  std::vector<double> values_x = mNcFile->readDoubleArr(
-                                   mNcidX,
-                                   start_dim1,
-                                   start_dim2,
-                                   count_dim1,
-                                   count_dim2
-                                 );
+    values_x = mNcFile->readDoubleArr(
+                 mNcidX,
+                 start_dim1,
+                 start_dim2,
+                 count_dim1,
+                 count_dim2
+               );
+  }
 
   for ( size_t i = 0; i < copyValues; ++i )
   {
@@ -510,25 +526,46 @@ size_t MDAL::CFDataset2D::vectorData( size_t indexStart, size_t count, double *b
 
   size_t copyValues = std::min( mValues - indexStart, count );
 
-  size_t start_dim1 = mTimeFirstDim ?  mTs : indexStart;
-  size_t start_dim2 = mTimeFirstDim ?  indexStart : mTs;
-  size_t count_dim1 = mTimeFirstDim ?  1 : copyValues;
-  size_t count_dim2 = mTimeFirstDim ?  copyValues : 1;
+  std::vector<double> values_x;
+  std::vector<double> values_y;
 
-  std::vector<double> values_x = mNcFile->readDoubleArr(
-                                   mNcidX,
-                                   start_dim1,
-                                   start_dim2,
-                                   count_dim1,
-                                   count_dim2
-                                 );
-  std::vector<double> values_y = mNcFile->readDoubleArr(
-                                   mNcidY,
-                                   start_dim1,
-                                   start_dim2,
-                                   count_dim1,
-                                   count_dim2
-                                 );
+  if ( mTimeLocation == CFDatasetGroupInfo::NoTimeDimension )
+  {
+    values_x = mNcFile->readDoubleArr(
+                 mNcidX,
+                 indexStart,
+                 copyValues
+               );
+
+    values_y = mNcFile->readDoubleArr(
+                 mNcidX,
+                 indexStart,
+                 copyValues
+               );
+  }
+  else
+  {
+    bool timeFirstDim = mTimeLocation == CFDatasetGroupInfo::TimeDimensionFirst;
+    size_t start_dim1 = timeFirstDim ?  mTs : indexStart;
+    size_t start_dim2 = timeFirstDim ?  indexStart : mTs;
+    size_t count_dim1 = timeFirstDim ?  1 : copyValues;
+    size_t count_dim2 = timeFirstDim ?  copyValues : 1;
+
+    values_x = mNcFile->readDoubleArr(
+                 mNcidX,
+                 start_dim1,
+                 start_dim2,
+                 count_dim1,
+                 count_dim2
+               );
+    values_y = mNcFile->readDoubleArr(
+                 mNcidY,
+                 start_dim1,
+                 start_dim2,
+                 count_dim1,
+                 count_dim2
+               );
+  }
 
   for ( size_t i = 0; i < copyValues; ++i )
   {

--- a/mdal/frmts/mdal_cf.hpp
+++ b/mdal/frmts/mdal_cf.hpp
@@ -53,10 +53,16 @@ namespace MDAL
 
   struct CFDatasetGroupInfo
   {
+    enum TimeLocation
+    {
+      NoTimeDimension = 0, //!< Dataset does not have time dimension at all, e.g. float TEMP(Cell)
+      TimeDimensionFirst, //!< Time dimension is first, e.g. float TEMP(Time, Cells)
+      TimeDimensionLast, //!< Time dimension is last, e.g. float TEMP(Cells, Time)
+    };
     std::string name; //!< Dataset group name
     CFDimensions::Type outputType;
     bool is_vector;
-    bool time_first_dim;
+    TimeLocation timeLocation;
     size_t nTimesteps;
     size_t nValues;
     int ncid_x; //!< NetCDF variable id
@@ -72,7 +78,7 @@ namespace MDAL
                    double fill_val_y,
                    int ncid_x,
                    int ncid_y,
-                   bool time_first_dim,
+                   CFDatasetGroupInfo::TimeLocation timeLocation,
                    size_t timesteps,
                    size_t values,
                    size_t ts,
@@ -88,7 +94,7 @@ namespace MDAL
       double mFillValY;
       int mNcidX; //!< NetCDF variable id
       int mNcidY; //!< NetCDF variable id
-      bool mTimeFirstDim;
+      CFDatasetGroupInfo::TimeLocation mTimeLocation;
       size_t mTimesteps;
       size_t mValues;
       size_t mTs;

--- a/mdal/frmts/mdal_netcdf.cpp
+++ b/mdal/frmts/mdal_netcdf.cpp
@@ -165,6 +165,46 @@ std::vector<double> NetCDFFile::readDoubleArr( int arr_id,
   return arr_val;
 }
 
+std::vector<double> NetCDFFile::readDoubleArr( int arr_id,
+    size_t start_dim,
+    size_t count_dim
+                                             ) const
+{
+  assert( mNcid != 0 );
+
+  const std::vector<size_t> startp = {start_dim};
+  const std::vector<size_t> countp = {count_dim};
+  const std::vector<ptrdiff_t> stridep = {1, 1};
+
+  std::vector<double> arr_val( count_dim );
+
+  nc_type typep;
+  if ( nc_inq_vartype( mNcid, arr_id, &typep ) != NC_NOERR ) throw MDAL_Status::Err_UnknownFormat;
+
+  if ( typep == NC_FLOAT )
+  {
+    std::vector<float> arr_val_f( count_dim );
+    if ( nc_get_vars_float( mNcid, arr_id, startp.data(), countp.data(), stridep.data(), arr_val_f.data() ) != NC_NOERR ) throw MDAL_Status::Err_UnknownFormat;
+    for ( size_t i = 0; i < count_dim; ++i )
+    {
+      const float val = arr_val_f[i];
+      if ( std::isnan( val ) )
+        arr_val[i] = std::numeric_limits<double>::quiet_NaN();
+      else
+        arr_val[i] = static_cast<double>( val );
+    }
+  }
+  else if ( typep == NC_DOUBLE )
+  {
+    if ( nc_get_vars_double( mNcid, arr_id, startp.data(), countp.data(), stridep.data(), arr_val.data() ) != NC_NOERR ) throw MDAL_Status::Err_UnknownFormat;
+  }
+  else
+  {
+    throw MDAL_Status::Err_UnknownFormat;
+  }
+  return arr_val;
+}
+
 bool NetCDFFile::hasArr( const std::string &name ) const
 {
   assert( mNcid != 0 );

--- a/mdal/frmts/mdal_netcdf.hpp
+++ b/mdal/frmts/mdal_netcdf.hpp
@@ -22,7 +22,7 @@ class NetCDFFile
     void openFile( const std::string &fileName );
 
     std::vector<int> readIntArr( const std::string &name, size_t dim ) const;
-    /** Reads hyperslap from double variable with 2 dimensions*/
+    /** Reads hyperslap from double variable - 2D array */
     std::vector<int> readIntArr( int arr_id,
                                  size_t start_dim1,
                                  size_t start_dim2,
@@ -30,7 +30,7 @@ class NetCDFFile
                                  size_t count_dim2
                                ) const;
 
-    /** Reads hyperslap from double variable with 1 dimension */
+    /** Reads hyperslap from double variable - 1D array */
     std::vector<int> readIntArr( int arr_id,
                                  size_t start_dim,
                                  size_t count_dim
@@ -38,12 +38,18 @@ class NetCDFFile
 
     std::vector<double> readDoubleArr( const std::string &name, size_t dim ) const;
 
-    /** Reads hyperslap from double variable */
+    /** Reads hyperslap from double variable - 2D array */
     std::vector<double> readDoubleArr( int arr_id,
                                        size_t start_dim1,
                                        size_t start_dim2,
                                        size_t count_dim1,
                                        size_t count_dim2
+                                     ) const;
+
+    /** Reads hyperslap from double variable - 1D array */
+    std::vector<double> readDoubleArr( int arr_id,
+                                       size_t start_dim,
+                                       size_t count_dim
                                      ) const;
 
     bool hasArr( const std::string &name ) const;

--- a/mdal/frmts/mdal_tuflowfv.cpp
+++ b/mdal/frmts/mdal_tuflowfv.cpp
@@ -424,7 +424,8 @@ void MDAL::DriverTuflowFV::addBedElevation( MDAL::MemoryMesh *mesh )
 
 std::string MDAL::DriverTuflowFV::getCoordinateSystemVariableName()
 {
-  return "";
+  const std::string projFile = MDAL::replace( mFileName, ".nc", ".prj" );
+  return "file://" + projFile;
 }
 
 std::set<std::string> MDAL::DriverTuflowFV::ignoreNetCDFVariables()
@@ -542,7 +543,6 @@ std::shared_ptr<MDAL::Dataset> MDAL::DriverTuflowFV::create3DDataset( std::share
         mNcFile
       );
 
-  // TODO use "Maximums" from file
   dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
   return std::move( dataset );
 }

--- a/mdal/frmts/mdal_tuflowfv.hpp
+++ b/mdal/frmts/mdal_tuflowfv.hpp
@@ -103,6 +103,10 @@ namespace MDAL
    *
    * Supports active flag.
    *
+   * There are special datasets for maximum/minimum/time of maximum/time of minimum.
+   * These datasets are not 1-1 with calculated max/min of time-datasets, since
+   * they are calculated with more fine methods directly in TUFLOW solvers
+   *
    * Both mesh and dataset is stored in single file.
    */
   class DriverTuflowFV: public DriverCF
@@ -121,9 +125,6 @@ namespace MDAL
       void parseNetCDFVariableMetadata( int varid, const std::string &variableName,
                                         std::string &name, bool *is_vector, bool *is_x ) override;
       std::string getTimeVariableName() const override;
-
-      // TODO CRS from prj file
-
       std::shared_ptr<MDAL::Dataset> create2DDataset(
         std::shared_ptr<MDAL::DatasetGroup> group,
         size_t ts,

--- a/mdal/frmts/mdal_tuflowfv.hpp
+++ b/mdal/frmts/mdal_tuflowfv.hpp
@@ -41,7 +41,7 @@ namespace MDAL
                          int ncidX,
                          int ncidY,
                          int ncidActive,
-                         bool timeFirstDim,
+                         CFDatasetGroupInfo::TimeLocation timeLocation,
                          size_t timesteps,
                          size_t values,
                          size_t ts,
@@ -59,6 +59,7 @@ namespace MDAL
                          int ncidX,
                          int ncidY,
                          int ncidActive,
+                         CFDatasetGroupInfo::TimeLocation timeLocation,
                          size_t timesteps,
                          size_t volumesCount,
                          size_t facesCount,
@@ -83,6 +84,7 @@ namespace MDAL
       size_t mTimesteps;
       size_t mFacesCount;
       size_t mLevelFacesCount;
+      CFDatasetGroupInfo::TimeLocation mTimeLocation;
       size_t mTs;
       std::shared_ptr<NetCDFFile> mNcFile;
 

--- a/mdal/mdal_data_model.cpp
+++ b/mdal/mdal_data_model.cpp
@@ -311,6 +311,12 @@ void MDAL::Mesh::setSourceCrsFromEPSG( int code )
   setSourceCrs( std::string( "EPSG:" ) + std::to_string( code ) );
 }
 
+void MDAL::Mesh::setSourceCrsFromPrjFile( const std::string &filename )
+{
+  const std::string proj = MDAL::readFileToString( filename );
+  setSourceCrs( proj );
+}
+
 size_t MDAL::Mesh::verticesCount() const
 {
   return mVerticesCount;

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -226,6 +226,7 @@ namespace MDAL
       void setSourceCrs( const std::string &str );
       void setSourceCrsFromWKT( const std::string &wkt );
       void setSourceCrsFromEPSG( int code );
+      void setSourceCrsFromPrjFile( const std::string &filename );
 
       virtual std::unique_ptr<MDAL::MeshVertexIterator> readVertices() = 0;
       virtual std::unique_ptr<MDAL::MeshFaceIterator> readFaces() = 0;

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -22,6 +22,17 @@ bool MDAL::fileExists( const std::string &filename )
   return in.good();
 }
 
+std::string MDAL::readFileToString( const std::string &filename )
+{
+  if ( MDAL::fileExists( filename ) )
+  {
+    std::ifstream t( filename );
+    std::stringstream buffer;
+    buffer << t.rdbuf();
+    return buffer.str();
+  }
+  return "";
+}
 
 bool MDAL::startsWith( const std::string &str, const std::string &substr, ContainsBehaviour behaviour )
 {
@@ -273,18 +284,27 @@ std::string MDAL::replace( const std::string &str, const std::string &substr, co
 // http://www.cplusplus.com/faq/sequences/strings/trim/
 std::string MDAL::trim( const std::string &s, const std::string &delimiters )
 {
+  if ( s.empty() )
+    return s;
+
   return ltrim( rtrim( s, delimiters ), delimiters );
 }
 
 // http://www.cplusplus.com/faq/sequences/strings/trim/
 std::string MDAL::ltrim( const std::string &s, const std::string &delimiters )
 {
+  if ( s.empty() )
+    return s;
+
   return s.substr( s.find_first_not_of( delimiters ) );
 }
 
 // http://www.cplusplus.com/faq/sequences/strings/trim/
 std::string MDAL::rtrim( const std::string &s, const std::string &delimiters )
 {
+  if ( s.empty() )
+    return s;
+
   return s.substr( 0, s.find_last_not_of( delimiters ) + 1 );
 }
 

--- a/mdal/mdal_utils.hpp
+++ b/mdal/mdal_utils.hpp
@@ -44,6 +44,7 @@ namespace MDAL
   std::string baseName( const std::string &filename );
   std::string dirName( const std::string &filename );
   std::string pathJoin( const std::string &path1, const std::string &path2 );
+  std::string readFileToString( const std::string &filename );
 
   // strings
   enum ContainsBehaviour

--- a/tests/test_tuflowfv.cpp
+++ b/tests/test_tuflowfv.cpp
@@ -18,6 +18,10 @@ TEST( MeshTuflowFVTest, TrapSteady053D )
   MDAL_Status s = MDAL_LastStatus();
   ASSERT_EQ( MDAL_Status::None, s );
 
+  const char *projection = MDAL_M_projection( m );
+  std::string proj( projection );
+  EXPECT_TRUE( proj.find( "WGS_1984_UTM_ZONE_60S" ) != std::string::npos );
+
   // ///////////
   // Vertices
   // ///////////
@@ -286,6 +290,9 @@ TEST( MeshTuflowFVTest, TrapSteady053DWithMaxes )
   EXPECT_NE( m, nullptr );
   MDAL_Status s = MDAL_LastStatus();
   ASSERT_EQ( MDAL_Status::None, s );
+
+  const char *projection = MDAL_M_projection( m );
+  EXPECT_EQ( std::string( "" ), std::string( projection ) );
 
   // ///////////
   // Vertices

--- a/tests/test_tuflowfv.cpp
+++ b/tests/test_tuflowfv.cpp
@@ -326,12 +326,12 @@ TEST( MeshTuflowFVTest, TrapSteady053DWithMaxes )
 
     double min, max;
     MDAL_D_minimumMaximum( ds, &min, &max );
-    EXPECT_DOUBLE_EQ( 0, min );
-    EXPECT_DOUBLE_EQ( 0, max );
+    EXPECT_DOUBLE_EQ( 4.9999990463256836, min );
+    EXPECT_DOUBLE_EQ( 5.0003223419189453, max );
 
     MDAL_G_minimumMaximum( g, &min, &max );
-    EXPECT_DOUBLE_EQ( 0, min );
-    EXPECT_DOUBLE_EQ( 0, max );
+    EXPECT_DOUBLE_EQ( 4.9999990463256836, min );
+    EXPECT_DOUBLE_EQ( 5.0003223419189453, max );
 
     double time = MDAL_D_time( ds );
     EXPECT_DOUBLE_EQ( 0, time );


### PR DESCRIPTION
- fix bug for reading of Maximum/Minimum datasets (they are 1 dimensional, so they do not have time dimension at all)
- fix bug for missing projection reading for TUFLOWFV files (there is .prj file in the directory with projection definition)