### PR TITLE
Introduce unknown time unit

### DIFF
--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -324,6 +324,9 @@ MDAL_EXPORT void MDAL_G_closeEditMode( DatasetGroupH group );
 //! Returns reference time for dataset group expressed in date with ISO8601 format, return "" if reference time is not defined
 MDAL_EXPORT const char *MDAL_G_referenceTime( DatasetGroupH group );
 
+//! Returns the time native time unit of the group
+MDAL_EXPORT const char *MDAL_G_TimeUnit( DatasetGroupH group );
+
 ///////////////////////////////////////////////////////////////////////////////////////
 /// DATASETS
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -333,6 +336,9 @@ MDAL_EXPORT DatasetGroupH MDAL_D_group( DatasetH dataset );
 
 //! Returns dataset time (hours)
 MDAL_EXPORT double MDAL_D_time( DatasetH dataset );
+
+//! Returns dataset time when time unit is unknown
+MDAL_EXPORT double MDAL_D_timeUnknownUnit( DatasetH dataset );
 
 //! Returns volumes count for the mesh (for 3D meshes)
 MDAL_EXPORT int MDAL_D_volumesCount( DatasetH dataset );

--- a/mdal/frmts/mdal_ascii_dat.cpp
+++ b/mdal/frmts/mdal_ascii_dat.cpp
@@ -135,6 +135,8 @@ void MDAL::DriverAsciiDat::loadOldFormat( std::ifstream &in,
   }
 
   group->setStatistics( MDAL::calculateStatistics( group ) );
+  if ( group->getMetadata( "TIMEUNITS" ) == "" )
+    group->setTimeUnit( MDAL::RelativeTimestamp::unknown );
   mesh->datasetGroups.push_back( group );
   group.reset();
 }
@@ -214,6 +216,8 @@ void MDAL::DriverAsciiDat::loadNewFormat(
         EXIT_WITH_ERROR( MDAL_Status::Err_UnknownFormat )
       }
       group->setStatistics( MDAL::calculateStatistics( group ) );
+      if ( group->getMetadata( "TIMEUNITS" ) == "" )
+        group->setTimeUnit( MDAL::RelativeTimestamp::unknown );
       mesh->datasetGroups.push_back( group );
       group.reset();
     }
@@ -242,7 +246,7 @@ void MDAL::DriverAsciiDat::loadNewFormat(
         EXIT_WITH_ERROR( MDAL_Status::Err_UnknownFormat )
       }
 
-      group->setMetadata( "TIMEUNITS", items[1] );
+      group->setTimeUnit( MDAL::parseDurationTimeUnit( items[1] ) );
     }
     else if ( cardType == "TS" && items.size() >= 3 )
     {
@@ -258,7 +262,6 @@ void MDAL::DriverAsciiDat::loadNewFormat(
         bool hasStatus = ( toBool( items[1] ) );
         readVertexTimestep( mesh, group, t, isVector, hasStatus, in );
       }
-
     }
     else
     {
@@ -267,6 +270,7 @@ void MDAL::DriverAsciiDat::loadNewFormat(
       debug( str.str() );
     }
   }
+
 }
 
 size_t MDAL::DriverAsciiDat::maximumId( const MDAL::Mesh *mesh ) const

--- a/mdal/frmts/mdal_binary_dat.cpp
+++ b/mdal/frmts/mdal_binary_dat.cpp
@@ -277,7 +277,7 @@ void MDAL::DriverBinaryDat::load( const std::string &datFile, MDAL::Mesh *mesh, 
             timeUnitStr = "unknown";
             break;
         }
-        group->setMetadata( "TIMEUNITS", timeUnitStr );
+        group->setTimeUnit( parseDurationTimeUnit( timeUnitStr ) );
         break;
 
       case CT_TS:
@@ -302,6 +302,10 @@ void MDAL::DriverBinaryDat::load( const std::string &datFile, MDAL::Mesh *mesh, 
     return exit_with_error( status, MDAL_Status::Err_UnknownFormat, "No datasets" );
 
   group->setStatistics( MDAL::calculateStatistics( group ) );
+
+  if ( group->getMetadata( "TIMEUNITS" ) == "" )
+    group->setTimeUnit( MDAL::RelativeTimestamp::unknown );
+
   mesh->datasetGroups.push_back( group );
 
   if ( groupMax && groupMax->datasets.size() > 0 )

--- a/mdal/frmts/mdal_cf.hpp
+++ b/mdal/frmts/mdal_cf.hpp
@@ -138,10 +138,10 @@ namespace MDAL
 
       void setProjection( MDAL::Mesh *m );
       cfdataset_info_map parseDatasetGroupInfo();
-      DateTime parseTime( std::vector<RelativeTimestamp> &times ); //Return the reference time
+      void parseTime( std::vector<RelativeTimestamp> &times, MDAL::DateTime &referenceTime, RelativeTimestamp::Unit &timeUnit ); //Return the reference time
       void addDatasetGroups( Mesh *mesh,
                              const std::vector<RelativeTimestamp> &times,
-                             const cfdataset_info_map &dsinfo_map, const DateTime &referenceTime );
+                             const cfdataset_info_map &dsinfo_map, const DateTime &referenceTime, const MDAL::RelativeTimestamp::Unit &timeUnit );
 
       std::string mFileName;
       std::shared_ptr<NetCDFFile> mNcFile;

--- a/mdal/frmts/mdal_flo2d.cpp
+++ b/mdal/frmts/mdal_flo2d.cpp
@@ -276,6 +276,9 @@ void MDAL::DriverFlo2D::parseTIMDEPFile( const std::string &datFileName, const s
   depthDsGroup->setStatistics( MDAL::calculateStatistics( depthDsGroup ) );
   flowDsGroup->setStatistics( MDAL::calculateStatistics( flowDsGroup ) );
   waterLevelDsGroup->setStatistics( MDAL::calculateStatistics( waterLevelDsGroup ) );
+  depthDsGroup->setTimeUnit( MDAL::RelativeTimestamp::hours );
+  waterLevelDsGroup->setTimeUnit( MDAL::RelativeTimestamp::hours );
+  flowDsGroup->setTimeUnit( MDAL::RelativeTimestamp::hours );
 
   mMesh->datasetGroups.push_back( depthDsGroup );
   mMesh->datasetGroups.push_back( flowDsGroup );
@@ -533,6 +536,7 @@ bool MDAL::DriverFlo2D::parseHDF5Datasets( MemoryMesh *mesh, const std::string &
 
     HdfAttribute timeUnitAttribute = grp.attribute( "TimeUnits" );
     std::string timeUnitString = timeUnitAttribute.readString();
+    MDAL::RelativeTimestamp::Unit timeUnit = parseDurationTimeUnit( timeUnitString );
 
     /* Min and Max arrays in TIMDEP.HDF5 files have dimensions 1xntimesteps .
         HdfDataset minDs = grp.dataset("Mins");
@@ -573,7 +577,7 @@ bool MDAL::DriverFlo2D::parseHDF5Datasets( MemoryMesh *mesh, const std::string &
     for ( size_t ts = 0; ts < timesteps; ++ts )
     {
       std::shared_ptr< MemoryDataset2D > output = std::make_shared< MemoryDataset2D >( ds.get() );
-      output->setTime( times[ts], parseDurationTimeUnit( timeUnitString ) );
+      output->setTime( times[ts], timeUnit );
 
       if ( isVector )
       {
@@ -601,6 +605,7 @@ bool MDAL::DriverFlo2D::parseHDF5Datasets( MemoryMesh *mesh, const std::string &
 
     // TODO use mins & maxs arrays
     ds->setStatistics( MDAL::calculateStatistics( ds ) );
+    ds->setTimeUnit( timeUnit );
     mesh->datasetGroups.push_back( ds );
 
   }

--- a/mdal/frmts/mdal_gdal.cpp
+++ b/mdal/frmts/mdal_gdal.cpp
@@ -316,6 +316,11 @@ MDAL::DateTime MDAL::DriverGdal::referenceTime() const
   return MDAL::DateTime();
 }
 
+MDAL::RelativeTimestamp::Unit MDAL::DriverGdal::timeUnit() const
+{
+  return MDAL::RelativeTimestamp::unknown;
+}
+
 void MDAL::DriverGdal::addDataToOutput( GDALRasterBandH raster_band, std::shared_ptr<MemoryDataset2D> tos, bool is_vector, bool is_x )
 {
   assert( raster_band );
@@ -433,6 +438,7 @@ void MDAL::DriverGdal::addDatasetGroups()
     // TODO use GDALComputeRasterMinMax
     group->setStatistics( MDAL::calculateStatistics( group ) );
     group->setReferenceTime( referenceTime() );
+    group->setTimeUnit( timeUnit() );
     mMesh->datasetGroups.push_back( group );
   }
 }

--- a/mdal/frmts/mdal_gdal.hpp
+++ b/mdal/frmts/mdal_gdal.hpp
@@ -95,6 +95,7 @@ namespace MDAL
       void fixRasterBands();
 
       virtual MDAL::DateTime referenceTime() const;
+      virtual MDAL::RelativeTimestamp::Unit timeUnit() const;
 
       std::string mFileName;
       const std::string mGdalDriverName; /* GDAL driver name */

--- a/mdal/frmts/mdal_gdal_grib.cpp
+++ b/mdal/frmts/mdal_gdal_grib.cpp
@@ -62,3 +62,8 @@ MDAL::DateTime MDAL::DriverGdalGrib::referenceTime() const
 {
   return mRefTime;
 }
+
+MDAL::RelativeTimestamp::Unit MDAL::DriverGdalGrib::timeUnit() const
+{
+  return MDAL::RelativeTimestamp::seconds;
+}

--- a/mdal/frmts/mdal_gdal_grib.hpp
+++ b/mdal/frmts/mdal_gdal_grib.hpp
@@ -30,6 +30,7 @@ namespace MDAL
                         ) override;
 
       MDAL::DateTime referenceTime() const override;
+      MDAL::RelativeTimestamp::Unit timeUnit() const override;
 
       /**
        * ref time (UTC sec)

--- a/mdal/frmts/mdal_gdal_netcdf.cpp
+++ b/mdal/frmts/mdal_gdal_netcdf.cpp
@@ -93,3 +93,8 @@ void MDAL::DriverGdalNetCDF::parseGlobals( const MDAL::DriverGdal::metadata_hash
 }
 
 MDAL::DateTime MDAL::DriverGdalNetCDF::referenceTime() const {return mRefTime;}
+
+MDAL::RelativeTimestamp::Unit MDAL::DriverGdalNetCDF::timeUnit() const
+{
+  return mTimeUnit;
+}

--- a/mdal/frmts/mdal_gdal_netcdf.hpp
+++ b/mdal/frmts/mdal_gdal_netcdf.hpp
@@ -32,6 +32,7 @@ namespace MDAL
       void parseGlobals( const metadata_hash &metadata ) override;
 
       MDAL::DateTime referenceTime() const override;
+      MDAL::RelativeTimestamp::Unit timeUnit() const override;
 
       RelativeTimestamp::Unit mTimeUnit;
       //! Take the first reference time parsed

--- a/mdal/frmts/mdal_hec2d.hpp
+++ b/mdal/frmts/mdal_hec2d.hpp
@@ -51,6 +51,7 @@ namespace MDAL
 
       std::vector<MDAL::RelativeTimestamp> mTimes ;
       DateTime mReferenceTime;
+      RelativeTimestamp::Unit mTimeUnit;
 
       // Pre 5.0.5 format
       bool canReadOldFormat( const std::string &fileType ) const;
@@ -68,21 +69,22 @@ namespace MDAL
                            const std::string rawDatasetName,
                            const std::string datasetName,
                            const std::vector<MDAL::RelativeTimestamp> &times,
-                           const DateTime &referenceTime );
+                           const DateTime &referenceTime,
+                           const RelativeTimestamp::Unit &timeUnit );
 
       void readFaceResults( const HdfFile &hdfFile,
                             const std::vector<size_t> &areaElemStartIndex,
                             const std::vector<std::string> &flowAreaNames );
 
-      std::shared_ptr<MDAL::MemoryDataset2D> readElemOutput(
-        const HdfGroup &rootGroup,
-        const std::vector<size_t> &areaElemStartIndex,
-        const std::vector<std::string> &flowAreaNames,
-        const std::string rawDatasetName,
-        const std::string datasetName,
-        const std::vector<MDAL::RelativeTimestamp> &times,
-        std::shared_ptr<MDAL::MemoryDataset2D> bed_elevation,
-        const DateTime &referenceTime );
+      std::shared_ptr<MDAL::MemoryDataset2D> readElemOutput( const HdfGroup &rootGroup,
+          const std::vector<size_t> &areaElemStartIndex,
+          const std::vector<std::string> &flowAreaNames,
+          const std::string rawDatasetName,
+          const std::string datasetName,
+          const std::vector<MDAL::RelativeTimestamp> &times,
+          std::shared_ptr<MDAL::MemoryDataset2D> bed_elevation,
+          const DateTime &referenceTime,
+          const RelativeTimestamp::Unit &timeUnit );
 
       std::shared_ptr<MDAL::MemoryDataset2D> readBedElevation(
         const HdfGroup &gGeom2DFlowAreas,

--- a/mdal/frmts/mdal_selafin.cpp
+++ b/mdal/frmts/mdal_selafin.cpp
@@ -527,6 +527,7 @@ void MDAL::DriverSelafin::addData( const std::vector<std::string> &var_names,
 
     MDAL::Statistics stats = MDAL::calculateStatistics( group );
     group->setStatistics( stats );
+    group->setTimeUnit( RelativeTimestamp::seconds );
   }
 }
 

--- a/mdal/frmts/mdal_sww.cpp
+++ b/mdal/frmts/mdal_sww.cpp
@@ -228,7 +228,10 @@ void MDAL::DriverSWW::readDatasetGroups(
         parsedVariableNames.insert( name );
       }
       if ( grp )
+      {
+        grp->setTimeUnit( RelativeTimestamp::seconds );
         mesh->datasetGroups.push_back( grp );
+      }
     }
   }
 }

--- a/mdal/frmts/mdal_xdmf.cpp
+++ b/mdal/frmts/mdal_xdmf.cpp
@@ -441,7 +441,8 @@ MDAL::DatasetGroups MDAL::DriverXdmf::parseXdmfXml( )
   {
     ++nTimesteps;
     xmlNodePtr timeNod = xmfFile.getCheckChild( gridNod, "Time" );
-    RelativeTimestamp time( xmfFile.queryDoubleAttribute( timeNod, "Value" ), RelativeTimestamp::hours ); //units, supposed to be hours
+    //xdmf generic format doesn't require time unit
+    RelativeTimestamp time( xmfFile.queryDoubleAttribute( timeNod, "Value" ), RelativeTimestamp::unknown );
     xmlNodePtr scalarNod = xmfFile.getCheckChild( gridNod, "Attribute" );
 
     for ( ;
@@ -564,6 +565,7 @@ MDAL::DatasetGroups MDAL::DriverXdmf::parseXdmfXml( )
 
     const MDAL::Statistics stats = MDAL::calculateStatistics( grp );
     grp->setStatistics( stats );
+    grp->setTimeUnit( RelativeTimestamp::unknown );
     // verify the integrity of the dataset
     if ( !std::isnan( stats.minimum ) )
       ret.push_back( grp );

--- a/mdal/frmts/mdal_xmdf.cpp
+++ b/mdal/frmts/mdal_xmdf.cpp
@@ -266,7 +266,7 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverXmdf::readXmdfGroupAsDatasetGrou
           );
   group->setIsScalar( !isVector );
   group->setDataLocation( MDAL_DataLocation::DataOnVertices2D );
-  group->setMetadata( "TIMEUNITS", timeUnitString );
+  group->setTimeUnit( timeUnit );
 
   // lazy loading of min and max of the dataset group
   std::vector<float> mins = dsMins.readArray();

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -4,6 +4,7 @@
 */
 
 #include <string>
+#include <cstring>
 #include <stddef.h>
 #include <limits>
 #include <assert.h>
@@ -769,6 +770,18 @@ const char *MDAL_G_referenceTime( DatasetGroupH group )
   return _return_str( g->referenceTime().toStandartCalendarISO8601() );
 }
 
+//! Returns reference time for dataset group expressed in date with ISO8601 format, return "" if reference time is not defined
+MDAL_EXPORT const char *MDAL_G_TimeUnit( DatasetGroupH group )
+{
+  if ( !group )
+  {
+    sLastStatus = MDAL_Status::Err_IncompatibleDataset;
+    return EMPTY_STR;
+  }
+  MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
+  return _return_str( g->getMetadata( "TIMEUNITS" ) ); ///TODO create a getTimeUnit() method
+}
+
 void MDAL_G_setMetadata( DatasetGroupH group, const char *key, const char *val )
 {
   if ( !group )
@@ -829,6 +842,19 @@ double MDAL_D_time( DatasetH dataset )
   }
   MDAL::Dataset *d = static_cast< MDAL::Dataset * >( dataset );
   return d->time( MDAL::RelativeTimestamp::hours );
+}
+
+
+
+double MDAL_D_timeUnknownUnit( DatasetH dataset )
+{
+  if ( !dataset )
+  {
+    sLastStatus = MDAL_Status::Err_IncompatibleDataset;
+    return NODATA;
+  }
+  MDAL::Dataset *d = static_cast< MDAL::Dataset * >( dataset );
+  return d->time( MDAL::RelativeTimestamp::unknown );
 }
 
 int MDAL_D_volumesCount( DatasetH dataset )

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -151,6 +151,44 @@ namespace MDAL
       std::string getMetadata( const std::string &key );
       void setMetadata( const std::string &key, const std::string &val );
 
+      void setTimeUnit( const MDAL::RelativeTimestamp::Unit unit )
+      {
+        std::string stringUnit;
+
+        switch ( unit )
+        {
+          case MDAL::RelativeTimestamp::milliseconds:
+            stringUnit = "milliseconds";
+            break;
+          case MDAL::RelativeTimestamp::seconds:
+            stringUnit = "seconds";
+            break;
+          case MDAL::RelativeTimestamp::minutes:
+            stringUnit = "minutes";
+            break;
+          case MDAL::RelativeTimestamp::hours:
+            stringUnit = "hours";
+            break;
+          case MDAL::RelativeTimestamp::days:
+            stringUnit = "days";
+            break;
+          case MDAL::RelativeTimestamp::weeks:
+            stringUnit = "weeks";
+            break;
+          case MDAL::RelativeTimestamp::months_CF:
+            stringUnit = "months_CF";
+            break;
+          case MDAL::RelativeTimestamp::exact_years:
+            stringUnit = "exact_year";
+            break;
+          case MDAL::RelativeTimestamp::unknown:
+            stringUnit = "unknown";
+            break;
+        }
+
+        setMetadata( "TIMEUNITS", stringUnit );
+      }
+
       std::string name();
       void setName( const std::string &name );
 
@@ -189,6 +227,7 @@ namespace MDAL
       std::string mUri; // file/uri from where it came
       Statistics mStatistics;
       DateTime mReferenceTime;
+      RelativeTimestamp::Unit timeUnit = RelativeTimestamp::hours;
   };
 
   typedef std::vector<std::shared_ptr<DatasetGroup>> DatasetGroups;

--- a/mdal/mdal_datetime.cpp
+++ b/mdal/mdal_datetime.cpp
@@ -16,6 +16,8 @@ constexpr double MILLISECONDS_IN_WEEK = 1000 * 60 * 60 * 24 * 7;
 constexpr double MILLISECONDS_IN_EXACT_YEAR = 3.15569259747e10; //CF Compliant
 constexpr double MILLISECONDS_IN_MONTH_CF = MILLISECONDS_IN_EXACT_YEAR / 12.0; //CF Compliant
 
+constexpr double MILLISECONDS_IN_UNKNOWN = 1000000;
+
 MDAL::DateTime::DateTime() = default;
 
 MDAL::DateTime::DateTime( int year, int month, int day, int hours, int minutes, double seconds, MDAL::DateTime::Calendar calendar )
@@ -307,6 +309,9 @@ MDAL::RelativeTimestamp::RelativeTimestamp( double duration, MDAL::RelativeTimes
     case MDAL::RelativeTimestamp::exact_years:
       mDuration = int64_t( duration * MILLISECONDS_IN_EXACT_YEAR + 0.5 );
       break;
+    case MDAL::RelativeTimestamp::unknown:
+      mDuration = int64_t( duration * MILLISECONDS_IN_UNKNOWN + 0.5 );
+      break;
   }
 }
 
@@ -330,6 +335,9 @@ double MDAL::RelativeTimestamp::value( MDAL::RelativeTimestamp::Unit unit ) cons
       return double( mDuration ) / MILLISECONDS_IN_MONTH_CF;
     case MDAL::RelativeTimestamp::exact_years:
       return double( mDuration )  / MILLISECONDS_IN_EXACT_YEAR;
+    case MDAL::RelativeTimestamp::unknown:
+      return double( mDuration )  / MILLISECONDS_IN_UNKNOWN;
+
   }
 
   return 0;

--- a/mdal/mdal_datetime.hpp
+++ b/mdal/mdal_datetime.hpp
@@ -26,7 +26,8 @@ namespace MDAL
         days,
         weeks,
         months_CF,
-        exact_years
+        exact_years,
+        unknown
       };
 
       RelativeTimestamp();

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -648,15 +648,25 @@ std::string MDAL::prependZero( const std::string &str, size_t length )
 
 MDAL::RelativeTimestamp::Unit MDAL::parseDurationTimeUnit( const std::string &timeUnit )
 {
-  MDAL::RelativeTimestamp::Unit unit = MDAL::RelativeTimestamp::hours; //default unit
 
-  if ( timeUnit == "millisec" ||
-       timeUnit == "msec" ||
-       timeUnit == "millisecs" ||
-       timeUnit == "msecs"
+  if ( timeUnit == "hour" ||
+       timeUnit == "hours" ||
+       timeUnit == "Hour" ||
+       timeUnit == "Hours" ||
+       timeUnit == "h"  ||
+       timeUnit == "ho"  ||
+       timeUnit == "0"
      )
   {
-    unit = MDAL::RelativeTimestamp::milliseconds;
+    return MDAL::RelativeTimestamp::hours;
+  }
+  else if ( timeUnit == "millisec" ||
+            timeUnit == "msec" ||
+            timeUnit == "millisecs" ||
+            timeUnit == "msecs"
+          )
+  {
+    return MDAL::RelativeTimestamp::milliseconds;
   }
   else if ( timeUnit == "second" ||
             timeUnit == "seconds" ||
@@ -667,7 +677,7 @@ MDAL::RelativeTimestamp::Unit MDAL::parseDurationTimeUnit( const std::string &ti
             timeUnit == "se" || // ascii_dat format
             timeUnit == "2" )  // ascii_dat format
   {
-    unit = MDAL::RelativeTimestamp::seconds;
+    return MDAL::RelativeTimestamp::seconds;
   }
   else if ( timeUnit == "minute" ||
             timeUnit == "minutes" ||
@@ -677,29 +687,31 @@ MDAL::RelativeTimestamp::Unit MDAL::parseDurationTimeUnit( const std::string &ti
             timeUnit == "mi" || // ascii_dat format
             timeUnit == "1" ) // ascii_dat format
   {
-    unit = MDAL::RelativeTimestamp::minutes;
+    return MDAL::RelativeTimestamp::minutes;
   }
   else if ( timeUnit == "day" ||
             timeUnit == "days" ||
             timeUnit == "Days" )
   {
-    unit = MDAL::RelativeTimestamp::days;
+    return MDAL::RelativeTimestamp::days;
   }
   else if ( timeUnit == "week" ||
             timeUnit == "weeks" )
   {
-    unit = MDAL::RelativeTimestamp::weeks;
+    return MDAL::RelativeTimestamp::weeks;
   }
-
-
-  return unit;
+  else
+  {
+    std::cout << "********************************************* : unknown";
+    return MDAL::RelativeTimestamp::unknown;
+  }
 }
 
 MDAL::RelativeTimestamp::Unit MDAL::parseCFTimeUnit( std::string timeInformation )
 {
   auto strings = MDAL::split( timeInformation, ' ' );
-  if ( strings.size() < 3 )
-    return MDAL::RelativeTimestamp::hours; //default value
+  if ( strings.size() < 3 ) //No Cf compliant --> try to parse entire timeInformation string
+    return parseDurationTimeUnit( timeInformation ); //default value
 
   if ( strings[1] == "since" )
   {

--- a/tests/mdal_testutils.cpp
+++ b/tests/mdal_testutils.cpp
@@ -315,6 +315,11 @@ bool compareDurationInHours( double h1, double h2 )
   return fabs( h1 - h2 ) < 1.0 / 3600 / 1000;
 }
 
+bool compareDurationInUnknown( double h1, double h2 )
+{
+  return fabs( h1 - h2 ) < 1.0 / 1000000;
+}
+
 bool hasReferenceTime( DatasetGroupH group )
 {
   return std::strcmp( MDAL_G_referenceTime( group ), "" ) != 0;

--- a/tests/mdal_testutils.hpp
+++ b/tests/mdal_testutils.hpp
@@ -61,6 +61,9 @@ bool compareMeshFrames( MeshH meshA, MeshH meshB );
 //! Compare duration with millisecond precision
 bool compareDurationInHours( double h1, double h2 );
 
+//! Compare duration with millisecond precision
+bool compareDurationInUnknown( double h1, double h2 );
+
 //! test if reference time is defined
 bool hasReferenceTime( DatasetGroupH group );
 

--- a/tests/test_3di.cpp
+++ b/tests/test_3di.cpp
@@ -113,7 +113,7 @@ TEST( Mesh3DiTest, Mesh2D4cells301steps )
   ASSERT_NE( g, nullptr );
 
   meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "waterlevel" ), std::string( name ) );
@@ -155,7 +155,7 @@ TEST( Mesh3DiTest, Mesh2D4cells301steps )
   ASSERT_NE( g, nullptr );
 
   meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "flow velocity in cell centre" ), std::string( name ) );
@@ -186,6 +186,8 @@ TEST( Mesh3DiTest, Mesh2D4cells301steps )
   EXPECT_DOUBLE_EQ( 8.4487915942199819e-14, max );
 
   EXPECT_TRUE( compareReferenceTime( g, "2014-01-01T00:00:00" ) );
+
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( time, 0.22222222222 ) );
@@ -219,6 +221,8 @@ TEST( Mesh3DiTest, Mesh2D16cells7steps )
   ASSERT_NE( ds, nullptr );
 
   EXPECT_TRUE( compareReferenceTime( g, "2014-01-01T00:00:00" ) );
+
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   ds = MDAL_G_dataset( g, 6 );
   double time = MDAL_D_time( ds );

--- a/tests/test_ascii_dat.cpp
+++ b/tests/test_ascii_dat.cpp
@@ -64,7 +64,7 @@ TEST( MeshAsciiDatTest, QuadAndTriangleFaceScalarFileWithNumberingGaps )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *key = MDAL_G_metadataKey( g, 0 );
   EXPECT_EQ( std::string( "name" ), std::string( key ) );
@@ -188,6 +188,8 @@ TEST( MeshAsciiDatTest, QuadAndTriangleFaceScalarFile )
   EXPECT_EQ( 0, MDAL_D_maximumVerticalLevelCount( ds ) );
   EXPECT_EQ( 0, MDAL_G_maximumVerticalLevelCount( g ) );
 
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) );
+
   double time = MDAL_D_time( ds );
   EXPECT_DOUBLE_EQ( 1, time );
 
@@ -256,6 +258,8 @@ TEST( MeshAsciiDatTest, QuadAndTriangleFaceVectorFile )
   MDAL_G_minimumMaximum( g, &min, &max );
   EXPECT_DOUBLE_EQ( 1.4142135623730951, min );
   EXPECT_DOUBLE_EQ( 2.8284271247461903, max );
+
+  EXPECT_EQ( std::string( "minutes" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_DOUBLE_EQ( 1, time );
@@ -329,7 +333,7 @@ TEST( MeshAsciiDatTest, QuadAndTriangleVertexScalarOldFile )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *key = MDAL_G_metadataKey( g, 0 );
     EXPECT_EQ( std::string( "name" ), std::string( key ) );
@@ -452,6 +456,8 @@ TEST( MeshAsciiDatTest, QuadAndTriangleVertexVectorFile )
   int count = MDAL_D_valueCount( ds );
   ASSERT_EQ( 5, count );
 
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
   double time = MDAL_D_time( ds );
   EXPECT_DOUBLE_EQ( 0, time );
 
@@ -483,7 +489,7 @@ TEST( MeshAsciiDatTest, QuadAndTriangleVertexVectorOldFile )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *key = MDAL_G_metadataKey( g, 0 );
   EXPECT_EQ( std::string( "name" ), std::string( key ) );
@@ -509,8 +515,10 @@ TEST( MeshAsciiDatTest, QuadAndTriangleVertexVectorOldFile )
   int count = MDAL_D_valueCount( ds );
   ASSERT_EQ( 5, count );
 
-  double time = MDAL_D_time( ds );
-  EXPECT_DOUBLE_EQ( 0, time );
+  EXPECT_EQ( std::string( "unknown" ), std::string( MDAL_G_TimeUnit( g ) ) );
+
+  double time = MDAL_D_timeUnknownUnit( ds );
+  EXPECT_TRUE( compareDurationInUnknown( 0, time ) );
 
   double value = getValueX( ds, 0 );
   EXPECT_DOUBLE_EQ( 1, value );

--- a/tests/test_binary_dat.cpp
+++ b/tests/test_binary_dat.cpp
@@ -35,7 +35,7 @@ TEST( MeshBinaryDatTest, QuadAndTriangleFile )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Water Depth (m)" ), std::string( name ) );
@@ -56,8 +56,10 @@ TEST( MeshBinaryDatTest, QuadAndTriangleFile )
   int active = getActive( ds, 0 );
   EXPECT_EQ( 1, active );
 
-  double time = MDAL_D_time( ds );
-  EXPECT_DOUBLE_EQ( 0, time );
+  EXPECT_EQ( std::string( "unknown" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
+  double time = MDAL_D_timeUnknownUnit( ds );
+  EXPECT_TRUE( compareDurationInUnknown( 0, time ) );
 
   int count = MDAL_D_valueCount( ds );
   ASSERT_EQ( 5, count );
@@ -114,6 +116,8 @@ TEST( MeshBinaryDatTest, RegularGridVectorFile )
   EXPECT_DOUBLE_EQ( 0, value );
 
   EXPECT_FALSE( hasReferenceTime( g ) );
+
+  EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( time, 4.1666666666 ) );
@@ -238,7 +242,7 @@ TEST( MeshBinaryDatTest, WriteScalarTest )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "scalarGrp" ), std::string( name ) );
@@ -334,7 +338,7 @@ TEST( MeshBinaryDatTest, WriteVectorTest )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "vectorGrp" ), std::string( name ) );

--- a/tests/test_flo2d.cpp
+++ b/tests/test_flo2d.cpp
@@ -452,7 +452,7 @@ TEST( MeshFlo2dTest, BarnHDF5 )
   ASSERT_NE( g, nullptr );
 
   meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "FLOW DEPTH" ), std::string( name ) );
@@ -466,6 +466,8 @@ TEST( MeshFlo2dTest, BarnHDF5 )
   ASSERT_EQ( 20, MDAL_G_datasetCount( g ) );
   ds = MDAL_G_dataset( g, 0 );
   ASSERT_NE( ds, nullptr );
+
+  EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( 0.10124753560882101, time ) );
@@ -499,7 +501,7 @@ TEST( MeshFlo2dTest, BarnHDF5 )
   ASSERT_NE( g, nullptr );
 
   meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Velocity" ), std::string( name ) );
@@ -531,6 +533,8 @@ TEST( MeshFlo2dTest, BarnHDF5 )
   MDAL_D_minimumMaximum( ds, &min, &max );
   EXPECT_DOUBLE_EQ( 0.1241119660936652, min );
   EXPECT_DOUBLE_EQ( 2.847882132344469, max );
+
+  EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   MDAL_CloseMesh( m );
 }
@@ -632,7 +636,7 @@ TEST( MeshFlo2dTest, basic )
     ASSERT_NE( g, nullptr );
 
     meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "Depth" ), std::string( name ) );
@@ -666,6 +670,8 @@ TEST( MeshFlo2dTest, basic )
     MDAL_G_minimumMaximum( g, &min, &max );
     EXPECT_DOUBLE_EQ( 1, min );
     EXPECT_DOUBLE_EQ( 3, max );
+
+    EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
     double time = MDAL_D_time( ds );
     EXPECT_TRUE( compareDurationInHours( 0.5, time ) );
@@ -846,7 +852,7 @@ TEST( MeshFlo2dTest, pro_16_02_14 )
   ASSERT_NE( g, nullptr );
 
   meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Depth" ), std::string( name ) );
@@ -860,6 +866,8 @@ TEST( MeshFlo2dTest, pro_16_02_14 )
   ASSERT_EQ( 4, MDAL_G_datasetCount( g ) );
   ds = MDAL_G_dataset( g, 2 );
   ASSERT_NE( ds, nullptr );
+
+  EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( 150.0, time ) );

--- a/tests/test_gdal_grib.cpp
+++ b/tests/test_gdal_grib.cpp
@@ -23,7 +23,7 @@ TEST( MeshGdalGribTest, ScalarFile )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Primary wave mean period [s]" ), std::string( name ) );
@@ -50,6 +50,8 @@ TEST( MeshGdalGribTest, ScalarFile )
   double value = getValue( ds, 1600 );
   EXPECT_TRUE( compareDurationInHours( 15.34, value ) );
 
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
   EXPECT_TRUE( compareReferenceTime( g, "2016-03-01T06:00:00" ) );
 
   ds = MDAL_G_dataset( g, 1 );
@@ -72,7 +74,7 @@ TEST( MeshGdalGribTest, VectorFile )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "wind [m/s]" ), std::string( name ) );
@@ -102,6 +104,8 @@ TEST( MeshGdalGribTest, VectorFile )
   double valueY = getValueY( ds, 1600 );
   EXPECT_DOUBLE_EQ( 2.8200097656250001, valueY );
 
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
   EXPECT_TRUE( compareReferenceTime( g, "2016-03-01T06:00:00" ) );
 
   ds = MDAL_G_dataset( g, 1 );
@@ -127,7 +131,7 @@ TEST( MeshGdalGribTest, WithoutNODATA )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "flow" ), std::string( name ) );
@@ -157,6 +161,8 @@ TEST( MeshGdalGribTest, WithoutNODATA )
   double valueY = getValueY( ds, 1600 );
   EXPECT_DOUBLE_EQ( 1, valueY );
 
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
   EXPECT_TRUE( compareReferenceTime( g, "1970-01-01T00:00:00" ) );
 
   ds = MDAL_G_dataset( g, 0 );
@@ -181,7 +187,7 @@ TEST( MeshGdalGribTest, ScalarFileWithUComponent )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "10 metre wind [m/s]" ), std::string( name ) );
@@ -208,6 +214,8 @@ TEST( MeshGdalGribTest, ScalarFileWithUComponent )
 
   double value = getValue( ds, 1600 );
   EXPECT_DOUBLE_EQ( -0.818756103515625, value );
+
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   EXPECT_TRUE( compareReferenceTime( g, "2018-10-01T00:00:00" ) );
 

--- a/tests/test_gdal_netcdf.cpp
+++ b/tests/test_gdal_netcdf.cpp
@@ -36,7 +36,7 @@ TEST( MeshGdalNetCDFTest, Indonesia )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "Total cloud cover" ), std::string( name ) );
@@ -63,6 +63,8 @@ TEST( MeshGdalNetCDFTest, Indonesia )
 
     double value = getValue( ds, 50 );
     EXPECT_DOUBLE_EQ( 0.99988487698798889, value );
+
+    EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
     EXPECT_TRUE( compareReferenceTime( g, "1900-01-01T00:00:00" ) );
 

--- a/tests/test_hec2d.cpp
+++ b/tests/test_hec2d.cpp
@@ -71,7 +71,7 @@ TEST( MeshHec2dTest, simpleArea )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Bed Elevation" ), std::string( name ) );
@@ -106,7 +106,7 @@ TEST( MeshHec2dTest, simpleArea )
   ASSERT_NE( g, nullptr );
 
   meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Water Surface" ), std::string( name ) );
@@ -143,6 +143,8 @@ TEST( MeshHec2dTest, simpleArea )
 
   double time = MDAL_D_time( ds );
   EXPECT_DOUBLE_EQ( 0.0, time );
+
+  EXPECT_EQ( std::string( "days" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   EXPECT_TRUE( compareDurationInHours( 0, time ) );
 
@@ -183,7 +185,7 @@ TEST( MeshHec2dTest, MultiAreas )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Bed Elevation" ), std::string( name ) );
@@ -219,7 +221,7 @@ TEST( MeshHec2dTest, MultiAreas )
   ASSERT_NE( g, nullptr );
 
   meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Water Surface" ), std::string( name ) );
@@ -256,6 +258,8 @@ TEST( MeshHec2dTest, MultiAreas )
   MDAL_G_minimumMaximum( g, &min, &max );
   EXPECT_DOUBLE_EQ( 576.4375, min );
   EXPECT_DOUBLE_EQ( 706.2740478515625, max );
+
+  EXPECT_EQ( std::string( "days" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( 60, time ) );
@@ -294,7 +298,7 @@ TEST( MeshHec2dTest, model_505 )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Bed Elevation" ), std::string( name ) );
@@ -327,7 +331,7 @@ TEST( MeshHec2dTest, model_505 )
   ASSERT_NE( g, nullptr );
 
   meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Water Surface" ), std::string( name ) );
@@ -361,6 +365,8 @@ TEST( MeshHec2dTest, model_505 )
   MDAL_G_minimumMaximum( g, &min, &max );
   EXPECT_DOUBLE_EQ( 32, min );
   EXPECT_DOUBLE_EQ( 43.28509521484375, max );
+
+  EXPECT_EQ( std::string( "days" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( 0.083333335816860199, time ) );

--- a/tests/test_selafin.cpp
+++ b/tests/test_selafin.cpp
@@ -48,7 +48,7 @@ TEST( MeshSLFTest, MalpassetGeometry )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "bottom" ), std::string( name ) );
@@ -125,7 +125,7 @@ TEST( MeshSLFTest, MalpassetResultFrench )
   ASSERT_NE( r, nullptr );
 
   int meta_count = MDAL_G_metadataCount( r );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( r );
   EXPECT_EQ( std::string( "surface libre   m" ), std::string( name ) );
@@ -139,6 +139,8 @@ TEST( MeshSLFTest, MalpassetResultFrench )
   ASSERT_EQ( 2, MDAL_G_datasetCount( r ) );
   DatasetH ds = MDAL_G_dataset( r, 1 );
   ASSERT_NE( ds, nullptr );
+
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( r ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( 1.111111111, time ) );
@@ -171,7 +173,7 @@ TEST( MeshSLFTest, MalpassetResultFrench )
   ASSERT_NE( r, nullptr );
 
   meta_count = MDAL_G_metadataCount( r );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( r );
   EXPECT_EQ( std::string( "vitesse       ms" ), std::string( name ) );
@@ -203,6 +205,8 @@ TEST( MeshSLFTest, MalpassetResultFrench )
   MDAL_D_minimumMaximum( ds, &min, &max );
   EXPECT_DOUBLE_EQ( 2.3694833011052991e-12, min );
   EXPECT_DOUBLE_EQ( 7.5673562379016834, max );
+
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( r ) ) ) ;
 
   EXPECT_TRUE( compareReferenceTime( r, "1900-01-01T00:00:00" ) );
 

--- a/tests/test_sww.cpp
+++ b/tests/test_sww.cpp
@@ -114,7 +114,7 @@ TEST( MeshSWWTest, Cairns )
   ASSERT_NE( g, nullptr );
 
   meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "stage" ), std::string( name ) );
@@ -150,6 +150,8 @@ TEST( MeshSWWTest, Cairns )
   EXPECT_DOUBLE_EQ( 6.7305092811584473, max );
 
   EXPECT_FALSE( hasReferenceTime( g ) );
+
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( time, 0.083333333333 ) );

--- a/tests/test_tuflowfv.cpp
+++ b/tests/test_tuflowfv.cpp
@@ -114,7 +114,7 @@ TEST( MeshTuflowFVTest, TrapSteady053D )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "temperature" ), std::string( name ) );
@@ -173,6 +173,8 @@ TEST( MeshTuflowFVTest, TrapSteady053D )
     EXPECT_EQ( 10, MDAL_D_maximumVerticalLevelCount( ds ) );
     EXPECT_EQ( 10, MDAL_G_maximumVerticalLevelCount( g ) );
 
+    EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
     double time = MDAL_D_time( ds );
     EXPECT_TRUE( compareDurationInHours( 0.502121734619141, time ) );
 
@@ -189,7 +191,7 @@ TEST( MeshTuflowFVTest, TrapSteady053D )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "velocity" ), std::string( name ) );
@@ -234,6 +236,8 @@ TEST( MeshTuflowFVTest, TrapSteady053D )
     EXPECT_DOUBLE_EQ( 0, min );
     EXPECT_DOUBLE_EQ( 1.7670363355554111, max );
 
+    EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
     double time = MDAL_D_time( ds );
     EXPECT_TRUE( compareDurationInHours( 0.667265041139391, time ) );
 
@@ -249,7 +253,7 @@ TEST( MeshTuflowFVTest, TrapSteady053D )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "water depth" ), std::string( name ) );
@@ -287,6 +291,8 @@ TEST( MeshTuflowFVTest, TrapSteady053D )
     MDAL_G_minimumMaximum( g, &min, &max );
     EXPECT_DOUBLE_EQ( 1.1920928955078125e-07, min );
     EXPECT_DOUBLE_EQ( 2.488835334777832, max );
+
+    EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
     double time = MDAL_D_time( ds );
     EXPECT_TRUE( compareDurationInHours( 1.16755709277259, time ) );
@@ -331,7 +337,7 @@ TEST( MeshTuflowFVTest, TrapSteady053DWithMaxes )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "temperature/Maximums" ), std::string( name ) );

--- a/tests/test_ugrid.cpp
+++ b/tests/test_ugrid.cpp
@@ -117,7 +117,7 @@ TEST( MeshUgridTest, DFlow11Manzese )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Total bed shear stress" ), std::string( name ) );
@@ -151,6 +151,8 @@ TEST( MeshUgridTest, DFlow11Manzese )
   MDAL_G_minimumMaximum( g, &min, &max );
   EXPECT_DOUBLE_EQ( 0, min );
   EXPECT_DOUBLE_EQ( 15.907056943512494, max );
+
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( 0.0, time ) );
@@ -213,7 +215,7 @@ TEST( MeshUgridTest, DFlow11Simplebox )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "water depth at pressure points" ), std::string( name ) );
@@ -247,6 +249,8 @@ TEST( MeshUgridTest, DFlow11Simplebox )
   MDAL_G_minimumMaximum( g, &min, &max );
   EXPECT_DOUBLE_EQ( 2.1346136585097848, min );
   EXPECT_DOUBLE_EQ( 6.3681219945588952, max );
+
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( .0097222222222222224, time ) );
@@ -291,7 +295,7 @@ TEST( MeshUgridTest, DFlow12RivierGridClm )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Water level" ), std::string( name ) );
@@ -327,6 +331,8 @@ TEST( MeshUgridTest, DFlow12RivierGridClm )
   MDAL_G_minimumMaximum( g, &min, &max );
   EXPECT_DOUBLE_EQ( 2, min );
   EXPECT_DOUBLE_EQ( 12, max );
+
+  EXPECT_EQ( std::string( "hors" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( 183.5, time ) );
@@ -374,7 +380,7 @@ TEST( MeshUgridTest, DFlow12RivierGridMap )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Water level" ), std::string( name ) );
@@ -419,7 +425,7 @@ TEST( MeshUgridTest, DFlow12RivierGridMap )
   ASSERT_NE( g, nullptr );
 
   meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "Flow element center velocity vector" ), std::string( name ) );
@@ -451,6 +457,8 @@ TEST( MeshUgridTest, DFlow12RivierGridMap )
   MDAL_D_minimumMaximum( ds, &min, &max );
   EXPECT_DOUBLE_EQ( 0, min );
   EXPECT_DOUBLE_EQ( 0.66413616798770714, max );
+
+  EXPECT_EQ( std::string( "seconds" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   EXPECT_TRUE( compareReferenceTime( g, "2002-10-15T00:00:00" ) );
 
@@ -512,7 +520,7 @@ TEST( MeshUgridTest, ADCIRC )
   ASSERT_NE( g, nullptr );
 
   int meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   const char *name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "sea surface height" ), std::string( name ) );
@@ -557,7 +565,7 @@ TEST( MeshUgridTest, ADCIRC )
   ASSERT_NE( g, nullptr );
 
   meta_count = MDAL_G_metadataCount( g );
-  ASSERT_EQ( 1, meta_count );
+  ASSERT_EQ( 2, meta_count );
 
   name = MDAL_G_name( g );
   EXPECT_EQ( std::string( "barotropic current" ), std::string( name ) );
@@ -589,6 +597,8 @@ TEST( MeshUgridTest, ADCIRC )
   MDAL_D_minimumMaximum( ds, &min, &max );
   EXPECT_DOUBLE_EQ( 0, min );
   EXPECT_DOUBLE_EQ( 1.3282330120641679, max );
+
+  EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   EXPECT_TRUE( compareReferenceTime( g, "1970-01-01T00:00:00" ) );
 

--- a/tests/test_xdmf.cpp
+++ b/tests/test_xdmf.cpp
@@ -28,7 +28,7 @@ TEST( XdmfTest, Basement3HumpsTest )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "water_surface" ), std::string( name ) );
@@ -63,8 +63,10 @@ TEST( XdmfTest, Basement3HumpsTest )
     EXPECT_DOUBLE_EQ( 0.0, min );
     EXPECT_DOUBLE_EQ( 2.9100000000000001, max );
 
-    double time = MDAL_D_time( ds );
-    EXPECT_TRUE( compareDurationInHours( 20, time ) );
+    EXPECT_EQ( std::string( "unknown" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
+    double time = MDAL_D_timeUnknownUnit( ds );
+    EXPECT_TRUE( compareDurationInUnknown( 20, time ) );
 
     EXPECT_FALSE( hasReferenceTime( g ) );
   }
@@ -75,7 +77,7 @@ TEST( XdmfTest, Basement3HumpsTest )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "spec_discharge" ), std::string( name ) );
@@ -113,8 +115,10 @@ TEST( XdmfTest, Basement3HumpsTest )
     EXPECT_DOUBLE_EQ( 0.0, min );
     EXPECT_DOUBLE_EQ( 4.9994493491047303, max );
 
-    double time = MDAL_D_time( ds );
-    EXPECT_TRUE( compareDurationInHours( 20, time ) );
+    EXPECT_EQ( std::string( "unknown" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
+    double time = MDAL_D_timeUnknownUnit( ds );
+    EXPECT_TRUE( compareDurationInUnknown( 20, time ) );
 
     EXPECT_FALSE( hasReferenceTime( g ) );
   }
@@ -143,7 +147,7 @@ TEST( XdmfTest, Basement3Slopes )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "friction_chezy" ), std::string( name ) );
@@ -178,8 +182,10 @@ TEST( XdmfTest, Basement3Slopes )
     EXPECT_DOUBLE_EQ( 0.0, min );
     EXPECT_DOUBLE_EQ( 494.816927222965329, max );
 
-    double time = MDAL_D_time( ds );
-    EXPECT_TRUE( compareDurationInHours( 1, time ) );
+    EXPECT_EQ( std::string( "unknown" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
+    double time = MDAL_D_timeUnknownUnit( ds );
+    EXPECT_TRUE( compareDurationInUnknown( 1, time ) );
 
     EXPECT_FALSE( hasReferenceTime( g ) );
   }
@@ -190,7 +196,7 @@ TEST( XdmfTest, Basement3Slopes )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "delta_z" ), std::string( name ) );
@@ -225,8 +231,10 @@ TEST( XdmfTest, Basement3Slopes )
     EXPECT_DOUBLE_EQ( -8.3107706316809526e-05, min );
     EXPECT_DOUBLE_EQ( 0.0030000000000001137, max );
 
-    double time = MDAL_D_time( ds );
-    EXPECT_TRUE( compareDurationInHours( 1, time ) );
+    EXPECT_EQ( std::string( "unknown" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
+    double time = MDAL_D_timeUnknownUnit( ds );
+    EXPECT_TRUE( compareDurationInUnknown( 1, time ) );
 
     EXPECT_FALSE( hasReferenceTime( g ) );
   }
@@ -237,7 +245,7 @@ TEST( XdmfTest, Basement3Slopes )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "water_depth" ), std::string( name ) );
@@ -272,8 +280,12 @@ TEST( XdmfTest, Basement3Slopes )
     EXPECT_DOUBLE_EQ( 1.0093761225415925, min );
     EXPECT_DOUBLE_EQ( 3.0788896191491268, max );
 
-    double time = MDAL_D_time( ds );
-    EXPECT_DOUBLE_EQ( 1, time );
+    EXPECT_EQ( std::string( "unknown" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
+    double time = MDAL_D_timeUnknownUnit( ds );
+    EXPECT_TRUE( compareDurationInUnknown( 1, time ) );
+
+    EXPECT_FALSE( hasReferenceTime( g ) );
   }
 
   // FUNCTION: sqrt($0/($2-$3)*$0/($2-$3) + $1/($2-$3)*$1/($2-$3))
@@ -282,7 +294,7 @@ TEST( XdmfTest, Basement3Slopes )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "flow_velocity_abs" ), std::string( name ) );
@@ -317,8 +329,12 @@ TEST( XdmfTest, Basement3Slopes )
     EXPECT_DOUBLE_EQ( 1.4142135623730951, min );
     EXPECT_DOUBLE_EQ( 18.579443815111134, max );
 
-    double time = MDAL_D_time( ds );
-    EXPECT_DOUBLE_EQ( 1, time );
+    EXPECT_EQ( std::string( "unknown" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
+    double time = MDAL_D_timeUnknownUnit( ds );
+    EXPECT_TRUE( compareDurationInUnknown( 1, time ) );
+
+    EXPECT_FALSE( hasReferenceTime( g ) );
   }
 
   MDAL_CloseMesh( m );
@@ -344,7 +360,7 @@ TEST( XdmfTest, Basement3SimpleChannel )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "water_surface" ), std::string( name ) );
@@ -379,8 +395,10 @@ TEST( XdmfTest, Basement3SimpleChannel )
     EXPECT_DOUBLE_EQ( 0.0040000000000000001, min );
     EXPECT_DOUBLE_EQ( 0.48486232713374577, max );
 
-    double time = MDAL_D_time( ds );
-    EXPECT_TRUE( compareDurationInHours( 30, time ) );
+    EXPECT_EQ( std::string( "unknown" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
+    double time = MDAL_D_timeUnknownUnit( ds );
+    EXPECT_TRUE( compareDurationInUnknown( 30, time ) );
 
     EXPECT_FALSE( hasReferenceTime( g ) );
   }
@@ -408,7 +426,7 @@ TEST( XdmfTest, Basement3SimpleGeometry )
     ASSERT_NE( g, nullptr );
 
     int meta_count = MDAL_G_metadataCount( g );
-    ASSERT_EQ( 1, meta_count );
+    ASSERT_EQ( 2, meta_count );
 
     const char *name = MDAL_G_name( g );
     EXPECT_EQ( std::string( "water_surface" ), std::string( name ) );
@@ -443,8 +461,12 @@ TEST( XdmfTest, Basement3SimpleGeometry )
     EXPECT_DOUBLE_EQ( 1.8713530882459224, min );
     EXPECT_DOUBLE_EQ( 2.1451217674360481, max );
 
-    double time = MDAL_D_time( ds );
-    EXPECT_DOUBLE_EQ( 6, time );
+    EXPECT_EQ( std::string( "unknown" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
+    double time = MDAL_D_timeUnknownUnit( ds );
+    EXPECT_TRUE( compareDurationInUnknown( 6, time ) );
+
+    EXPECT_FALSE( hasReferenceTime( g ) );
   }
 
   MDAL_CloseMesh( m );
@@ -585,6 +607,8 @@ TEST( XdmfTest, Simple )
 
     valueY = getValueY( ds, 196 );
     EXPECT_DOUBLE_EQ( 0, valueY );
+
+    EXPECT_EQ( std::string( "unknown" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
     EXPECT_FALSE( hasReferenceTime( g ) );
   }

--- a/tests/test_xmdf.cpp
+++ b/tests/test_xmdf.cpp
@@ -107,6 +107,8 @@ TEST( MeshXmdfTest, RegularGridScalarDataset )
   EXPECT_DOUBLE_EQ( 0, min );
   EXPECT_DOUBLE_EQ( 1.0765361785888672, max );
 
+  EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
+
   double time = MDAL_D_time( ds );
   EXPECT_TRUE( compareDurationInHours( 4.166666666666, time ) );
 
@@ -261,6 +263,8 @@ TEST( MeshXmdfTest, CustomGroupsDataset )
   MDAL_G_minimumMaximum( g, &min, &max );
   EXPECT_DOUBLE_EQ( 180, max );
   EXPECT_DOUBLE_EQ( -179.99665832519531, min );
+
+  EXPECT_EQ( std::string( "hours" ), std::string( MDAL_G_TimeUnit( g ) ) ) ;
 
   ds = MDAL_G_dataset( g, 1 );
   double time = MDAL_D_time( ds );


### PR DESCRIPTION
New approach when time unit is unknown, for discussion :
Where there is a doubt for the time unit, MDAL considers the time unit as unknown and the time unit is stored for all format in the metadata of the dataset group.
So before asking for the time, QGIS can check if the time unit is known or not. If not, he will ask the user to choose the time unit or a factor to convert the time in hours, as QGIS read it.