### PR TITLE
fix #187 bug when reading binary dat files

### DIFF
--- a/mdal/frmts/mdal_2dm.cpp
+++ b/mdal/frmts/mdal_2dm.cpp
@@ -98,7 +98,7 @@ bool MDAL::Driver2dm::canReadMesh( const std::string &uri )
 {
   std::ifstream in( uri, std::ifstream::in );
   std::string line;
-  if ( !std::getline( in, line ) || !startsWith( line, "MESH2D" ) )
+  if ( !MDAL::getHeaderLine( in, line ) || !startsWith( line, "MESH2D" ) )
   {
     return false;
   }

--- a/mdal/frmts/mdal_ascii_dat.cpp
+++ b/mdal/frmts/mdal_ascii_dat.cpp
@@ -44,7 +44,7 @@ bool MDAL::DriverAsciiDat::canReadDatasets( const std::string &uri )
 {
   std::ifstream in( uri, std::ifstream::in );
   std::string line;
-  if ( !std::getline( in, line ) )
+  if ( !MDAL::getHeaderLine( in, line ) )
   {
     return false;
   }

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -772,3 +772,12 @@ MDAL::DateTime MDAL::parseCFReferenceTime( const std::string &timeInformation, c
 
   return MDAL::DateTime( year, month, day, hours, minutes, seconds, calendar );
 }
+
+bool MDAL::getHeaderLine( std::ifstream &stream, std::string &line )
+{
+  if ( !stream.is_open() ) return false;
+  char b[100] = "";
+  if ( ! stream.get( b, sizeof( b ) - 1, '\n' ) ) return false;
+  line = std::string( b );
+  return true;
+}

--- a/mdal/mdal_utils.hpp
+++ b/mdal/mdal_utils.hpp
@@ -12,6 +12,7 @@
 #include <limits>
 #include <sstream>
 #include <fstream>
+
 #include <algorithm>
 
 #include "mdal_data_model.hpp"
@@ -59,6 +60,9 @@ namespace MDAL
   std::string leftJustified( const std::string &str, size_t width, char fill = ' ' );
 
   std::string toLower( const std::string &std );
+
+  //! Get a first line from stream clipped to first 100 characters
+  bool getHeaderLine( std::ifstream &stream, std::string &line );
 
   /** Return 0 if not possible to convert */
   size_t toSizeT( const std::string &str );


### PR DESCRIPTION
fix #187 

problem was that the getLine loaded whole binary file to memory and the file contained the required textstring, so the ASCII DAT driver was confused and started to parse the binary file 