### PR TITLE
fix duplicate Z value dataset

### DIFF
--- a/mdal/frmts/mdal_cf.cpp
+++ b/mdal/frmts/mdal_cf.cpp
@@ -143,8 +143,6 @@ MDAL::cfdataset_info_map MDAL::DriverCF::parseDatasetGroupInfo()
   }
   while ( true );
 
-  if ( dsinfo_map.size() == 0 ) throw MDAL::Error( MDAL_Status::Err_InvalidData, "Could not parse dataset group info" );
-
   return dsinfo_map;
 }
 

--- a/mdal/frmts/mdal_ugrid.cpp
+++ b/mdal/frmts/mdal_ugrid.cpp
@@ -300,6 +300,7 @@ std::set<std::string> MDAL::DriverUgrid::ignoreNetCDFVariables()
     parse2VariablesFromAttribute( mesh, "node_coordinates", xName, yName, true );
     ignore_variables.insert( xName );
     ignore_variables.insert( yName );
+    ignore_variables.insert( nodeZVariableName() );
     ignore_variables.insert( mNcFile->getAttrStr( mesh, "edge_node_connectivity" ) );
     parse2VariablesFromAttribute( mesh, "edge_coordinates", xName, yName, true );
     if ( !xName.empty() )

--- a/tests/test_ugrid.cpp
+++ b/tests/test_ugrid.cpp
@@ -60,7 +60,7 @@ TEST( MeshUgridTest, DFlow11Manzese )
   f_v = getFaceVerticesIndexAt( m, 1, 3 );
   EXPECT_EQ( 26, f_v );
 
-  ASSERT_EQ( 11, MDAL_M_datasetGroupCount( m ) );
+  ASSERT_EQ( 10, MDAL_M_datasetGroupCount( m ) );
 
   // ///////////
   // Dataset
@@ -159,7 +159,7 @@ TEST( MeshUgridTest, DFlow11Simplebox )
   // ///////////
   // dataset
   // ///////////
-  ASSERT_EQ( 11, MDAL_M_datasetGroupCount( m ) );
+  ASSERT_EQ( 10, MDAL_M_datasetGroupCount( m ) );
 
   DatasetGroupH g = MDAL_M_datasetGroup( m, 7 );
   ASSERT_NE( g, nullptr );
@@ -237,7 +237,7 @@ TEST( MeshUgridTest, DFlow12RivierGridClm )
   // ///////////
   // dataset
   // ///////////
-  ASSERT_EQ( 7, MDAL_M_datasetGroupCount( m ) );
+  ASSERT_EQ( 6, MDAL_M_datasetGroupCount( m ) );
 
   DatasetGroupH g = MDAL_M_datasetGroup( m, 3 );
   ASSERT_NE( g, nullptr );
@@ -320,7 +320,7 @@ TEST( MeshUgridTest, DFlow12RivierGridMap )
   // ///////////
   // scalar dataset
   // ///////////
-  ASSERT_EQ( 7, MDAL_M_datasetGroupCount( m ) );
+  ASSERT_EQ( 6, MDAL_M_datasetGroupCount( m ) );
 
   DatasetGroupH g = MDAL_M_datasetGroup( m, 3 );
   ASSERT_NE( g, nullptr );


### PR DESCRIPTION
For `UGRID` format (others CF derived seem ok), the Z value of vertex appears in the dataset twice :
- under the name "Bed Elevation", this dataset group come from the addition of the bed elevation here : https://github.com/lutraconsulting/MDAL/blob/bb4ed1f4c105d0ea52372715dbd73e572d1658dd/mdal/frmts/mdal_cf.cpp#L424

- under the name of the CF variable when dataset are loaded.

To avoid this double dataset and to be consistent with the other format, this PR keeps the first under the name "Bed Elevation".

To permit mesh with no dataset (for exemple TIN), this PR remove the throw of an exception if there is no no dataset after parsing the CF File.

Tests are adapted.