### PR TITLE
Avoid unnecessary copy of face data

### DIFF
--- a/mdal/mdal_memory_data_model.cpp
+++ b/mdal/mdal_memory_data_model.cpp
@@ -52,8 +52,9 @@ void MDAL::MemoryDataset2D::activateFaces( MDAL::MemoryMesh *mesh )
 
   for ( unsigned int idx = 0; idx < nFaces; ++idx )
   {
-    Face elem = mesh->faces.at( idx );
-    for ( size_t i = 0; i < elem.size(); ++i )
+    const Face &elem = mesh->faces.at( idx );
+    const std::size_t elemSize = elem.size();
+    for ( size_t i = 0; i < elemSize; ++i )
     {
       const size_t vertexIndex = elem[i];
       if ( isScalar )
@@ -267,8 +268,9 @@ size_t MDAL::MemoryMeshFaceIterator::next(
     if ( mLastFaceIndex + faceIndex >= maxFaces )
       break;
 
-    const Face f = mMemoryMesh->faces[mLastFaceIndex + faceIndex];
-    for ( size_t faceVertexIndex = 0; faceVertexIndex < f.size(); ++faceVertexIndex )
+    const Face &f = mMemoryMesh->faces[mLastFaceIndex + faceIndex];
+    const std::size_t faceSize = f.size();
+    for ( size_t faceVertexIndex = 0; faceVertexIndex < faceSize; ++faceVertexIndex )
     {
       assert( vertexIndex < vertexIndicesBufferLen );
       vertexIndicesBuffer[vertexIndex] = static_cast<int>( f[faceVertexIndex] );

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -11,7 +11,6 @@
 #include <sstream>
 #include <math.h>
 #include <assert.h>
-#include <cmath>
 #include <string.h>
 #include <stdio.h>
 #include <ctime>
@@ -355,11 +354,6 @@ MDAL::BBox MDAL::computeExtent( const MDAL::Vertices &vertices )
     if ( n.y < b.minY ) b.minY = n.y;
   }
   return b;
-}
-
-bool MDAL::equals( double val1, double val2, double eps )
-{
-  return fabs( val1 - val2 ) < eps;
 }
 
 double MDAL::safeValue( double val, double nodata, double eps )

--- a/mdal/mdal_utils.hpp
+++ b/mdal/mdal_utils.hpp
@@ -12,6 +12,7 @@
 #include <limits>
 #include <sstream>
 #include <fstream>
+#include <cmath>
 
 #include <algorithm>
 
@@ -33,7 +34,10 @@ namespace MDAL
   bool isNativeLittleEndian();
 
   // numbers
-  bool equals( double val1, double val2, double eps = std::numeric_limits<double>::epsilon() );
+  inline bool equals( double val1, double val2, double eps = std::numeric_limits<double>::epsilon() )
+  {
+    return fabs( val1 - val2 ) < eps;
+  }
 
   //! returns quiet_NaN if value equals nodata value, otherwise returns val itself
   double safeValue( double val, double nodata, double eps = std::numeric_limits<double>::epsilon() );


### PR DESCRIPTION
This speeds up loading the `Hurricane Michael data from Copernicus ECMWF.nc` demo data in QGIS by ~2x.