### PR TITLE
SELAFIN Lazy loading, mesh and dataset

### DIFF
--- a/mdal/frmts/mdal_2dm.cpp
+++ b/mdal/frmts/mdal_2dm.cpp
@@ -22,19 +22,11 @@
 
 #define DRIVER_NAME "2DM"
 
-MDAL::Mesh2dm::Mesh2dm( size_t verticesCount,
-                        size_t edgesCount,
-                        size_t facesCount,
-                        size_t faceVerticesMaximumCount,
-                        MDAL::BBox extent,
+MDAL::Mesh2dm::Mesh2dm( size_t faceVerticesMaximumCount,
                         const std::string &uri,
                         const std::map<size_t, size_t> vertexIDtoIndex )
   : MemoryMesh( DRIVER_NAME,
-                verticesCount,
-                edgesCount,
-                facesCount,
                 faceVerticesMaximumCount,
-                extent,
                 uri )
   , mVertexIDtoIndex( vertexIDtoIndex )
 {
@@ -276,22 +268,18 @@ std::unique_ptr<MDAL::Mesh> MDAL::Driver2dm::load( const std::string &meshFile, 
 
   std::unique_ptr< Mesh2dm > mesh(
     new Mesh2dm(
-      vertices.size(),
-      edges.size(),
-      faces.size(),
       MAX_VERTICES_PER_FACE_2DM,
-      computeExtent( vertices ),
       mMeshFile,
       vertexIDtoIndex
     )
   );
-  mesh->faces = faces;
-  mesh->vertices = vertices;
-  mesh->edges = edges;
+  mesh->setFaces( std::move( faces ) );
+  mesh->setVertices( std::move( vertices ) );
+  mesh->setEdges( std::move( edges ) );
 
   // Add Bed Elevations
   MDAL::addFaceScalarDatasetGroup( mesh.get(), elementCenteredElevation, "Bed Elevation (Face)" );
-  MDAL::addBedElevationDatasetGroup( mesh.get(), vertices );
+  MDAL::addBedElevationDatasetGroup( mesh.get(), mesh->vertices() );
 
   return std::unique_ptr<Mesh>( mesh.release() );
 }

--- a/mdal/frmts/mdal_2dm.hpp
+++ b/mdal/frmts/mdal_2dm.hpp
@@ -22,11 +22,7 @@ namespace MDAL
   class Mesh2dm: public MemoryMesh
   {
     public:
-      Mesh2dm( size_t verticesCount,
-               size_t edgesCount,
-               size_t facesCount,
-               size_t faceVerticesMaximumCount,
-               BBox extent,
+      Mesh2dm( size_t faceVerticesMaximumCount,
                const std::string &uri,
                const std::map<size_t, size_t> vertexIDtoIndex
              );

--- a/mdal/frmts/mdal_cf.cpp
+++ b/mdal/frmts/mdal_cf.cpp
@@ -563,17 +563,13 @@ std::unique_ptr< MDAL::Mesh > MDAL::DriverCF::load( const std::string &fileName,
     std::unique_ptr< MemoryMesh > mesh(
       new MemoryMesh(
         name(),
-        vertices.size(),
-        edges.size(),
-        faces.size(),
         mDimensions.size( mDimensions.MaxVerticesInFace ),
-        computeExtent( vertices ),
         mFileName
       )
     );
-    mesh->faces = faces;
-    mesh->edges = edges;
-    mesh->vertices = vertices;
+    mesh->setFaces( std::move( faces ) );
+    mesh->setEdges( std::move( edges ) );
+    mesh->setVertices( std::move( vertices ) );
     addBedElevation( mesh.get() );
     setProjection( mesh.get() );
 

--- a/mdal/frmts/mdal_esri_tin.cpp
+++ b/mdal/frmts/mdal_esri_tin.cpp
@@ -176,21 +176,17 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverEsriTin::load( const std::string &uri, c
     std::unique_ptr< MemoryMesh > mesh(
       new MemoryMesh(
         name(),
-        vertices.size(),
-        0,
-        faces.size(),
         3,
-        computeExtent( vertices ),
         uri
       )
     );
 
     //move the faces and the vertices in the mesh
-    mesh->faces = std::move( faces );
-    mesh->vertices = std::move( vertices );
+    mesh->setFaces( std::move( faces ) );
+    mesh->setVertices( std::move( vertices ) );
 
     //create the "Altitude" dataset
-    addBedElevationDatasetGroup( mesh.get(), mesh->vertices );
+    addBedElevationDatasetGroup( mesh.get(), mesh->vertices() );
     mesh->datasetGroups.back()->setName( "Altitude" );
 
     std::string crs = getCrsWkt( uri );

--- a/mdal/frmts/mdal_flo2d.cpp
+++ b/mdal/frmts/mdal_flo2d.cpp
@@ -498,16 +498,12 @@ void MDAL::DriverFlo2D::createMesh( const std::vector<CellCenter> &cells, double
   mMesh.reset(
     new MemoryMesh(
       name(),
-      vertices.size(),
-      0,
-      faces.size(),
       4, //maximum quads
-      computeExtent( vertices ),
       mDatFileName
     )
   );
-  mMesh->faces = faces;
-  mMesh->vertices = vertices;
+  mMesh->setFaces( std::move( faces ) );
+  mMesh->setVertices( std::move( vertices ) );
 }
 
 bool MDAL::DriverFlo2D::parseHDF5Datasets( MemoryMesh *mesh, const std::string &timedepFileName )

--- a/mdal/frmts/mdal_gdal.cpp
+++ b/mdal/frmts/mdal_gdal.cpp
@@ -448,16 +448,12 @@ void MDAL::DriverGdal::createMesh()
 
   mMesh.reset( new MemoryMesh(
                  name(),
-                 vertices.size(),
-                 0,
-                 faces.size(),
                  4, //maximum quads
-                 computeExtent( vertices ),
                  mFileName
                )
              );
-  mMesh->vertices = vertices;
-  mMesh->faces = faces;
+  mMesh->setVertices( std::move( vertices ) );
+  mMesh->setFaces( std::move( faces ) );
   bool proj_added = addSrcProj();
   if ( ( !proj_added ) && is_longitude_shifted )
   {

--- a/mdal/frmts/mdal_hec2d.cpp
+++ b/mdal/frmts/mdal_hec2d.cpp
@@ -632,16 +632,12 @@ void MDAL::DriverHec2D::parseMesh(
   mMesh.reset(
     new MemoryMesh(
       name(),
-      vertices.size(),
-      0,
-      faces.size(),
       maxVerticesInFace,
-      computeExtent( vertices ),
       mFileName
     )
   );
-  mMesh->faces = faces;
-  mMesh->vertices = vertices;
+  mMesh->setFaces( std::move( faces ) );
+  mMesh->setVertices( std::move( vertices ) );
 }
 
 MDAL::DriverHec2D::DriverHec2D()

--- a/mdal/frmts/mdal_selafin.cpp
+++ b/mdal/frmts/mdal_selafin.cpp
@@ -48,9 +48,9 @@ void MDAL::SerafinStreamReader::initialize( const std::string &fileName )
 
 bool MDAL::SerafinStreamReader::getStreamPrecision( )
 {
-  ignore_array_length( );
+  ignoreArrayLength( );
   ignore( 72 );
-  std::string varType = read_string_without_length( 8 );
+  std::string varType = readStringWithoutLength( 8 );
   bool ret;
   if ( varType == "SERAFIN" )
   {
@@ -64,22 +64,22 @@ bool MDAL::SerafinStreamReader::getStreamPrecision( )
   {
     throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Not found stream precision" );
   }
-  ignore_array_length( );
+  ignoreArrayLength( );
   return ret;
 }
 
-std::string MDAL::SerafinStreamReader::read_string( size_t len )
+std::string MDAL::SerafinStreamReader::readString( size_t len )
 {
-  size_t length = read_sizet();
+  size_t length = readSizet();
   if ( length != len ) throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Unable to read string" );
-  std::string ret = read_string_without_length( len );
-  ignore_array_length();
+  std::string ret = readStringWithoutLength( len );
+  ignoreArrayLength();
   return ret;
 }
 
-std::vector<double> MDAL::SerafinStreamReader::read_double_arr( size_t len )
+std::vector<double> MDAL::SerafinStreamReader::readDoubleArr( size_t len )
 {
-  size_t length = read_sizet();
+  size_t length = readSizet();
   if ( mStreamInFloatPrecision )
   {
     if ( length != len * 4 ) throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "File format problem while reading double array" );
@@ -91,13 +91,13 @@ std::vector<double> MDAL::SerafinStreamReader::read_double_arr( size_t len )
   std::vector<double> ret( len );
   for ( size_t i = 0; i < len; ++i )
   {
-    ret[i] = read_double();
+    ret[i] = readDouble();
   }
-  ignore_array_length();
+  ignoreArrayLength();
   return ret;
 }
 
-std::vector<double> MDAL::SerafinStreamReader::read_double_arr( const std::streampos &position, size_t offset, size_t len )
+std::vector<double> MDAL::SerafinStreamReader::readDoubleArr( const std::streampos &position, size_t offset, size_t len )
 {
   std::vector<double> ret( len );
   std::streamoff off;
@@ -108,50 +108,50 @@ std::vector<double> MDAL::SerafinStreamReader::read_double_arr( const std::strea
 
   mIn.seekg( position + off );
   for ( size_t i = 0; i < len; ++i )
-    ret[i] = read_double();
+    ret[i] = readDouble();
 
   return ret;
 }
 
-std::vector<int> MDAL::SerafinStreamReader::read_int_arr( size_t len )
+std::vector<int> MDAL::SerafinStreamReader::readIntArr( size_t len )
 {
-  size_t length = read_sizet();
+  size_t length = readSizet();
   if ( length != len * 4 ) throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "File format problem while reading int array" );
   std::vector<int> ret( len );
   for ( size_t i = 0; i < len; ++i )
   {
-    ret[i] = read_int();
+    ret[i] = readInt();
   }
-  ignore_array_length();
+  ignoreArrayLength();
   return ret;
 }
 
-std::vector<int> MDAL::SerafinStreamReader::read_int_arr( const std::streampos &position, size_t offset, size_t len )
+std::vector<int> MDAL::SerafinStreamReader::readIntArr( const std::streampos &position, size_t offset, size_t len )
 {
   std::vector<int> ret( len );
   std::streamoff off = offset * 4;
 
   mIn.seekg( position + off );
   for ( size_t i = 0; i < len; ++i )
-    ret[i] = read_int();
+    ret[i] = readInt();
 
   return ret;
 }
 
-std::vector<size_t> MDAL::SerafinStreamReader::read_size_t_arr( size_t len )
+std::vector<size_t> MDAL::SerafinStreamReader::readSizeTArr( size_t len )
 {
-  size_t length = read_sizet();
+  size_t length = readSizet();
   if ( length != len * 4 ) throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "File format problem while reading sizet array" );
   std::vector<size_t> ret( len );
   for ( size_t i = 0; i < len; ++i )
   {
-    ret[i] = read_sizet();
+    ret[i] = readSizet();
   }
-  ignore_array_length();
+  ignoreArrayLength();
   return ret;
 }
 
-std::string MDAL::SerafinStreamReader::read_string_without_length( size_t len )
+std::string MDAL::SerafinStreamReader::readStringWithoutLength( size_t len )
 {
   std::vector<char> ptr( len );
   mIn.read( ptr.data(), static_cast<int>( len ) );
@@ -171,7 +171,7 @@ std::string MDAL::SerafinStreamReader::read_string_without_length( size_t len )
   return ret;
 }
 
-double MDAL::SerafinStreamReader::read_double( )
+double MDAL::SerafinStreamReader::readDouble( )
 {
   double ret;
 
@@ -191,7 +191,7 @@ double MDAL::SerafinStreamReader::read_double( )
 }
 
 
-int MDAL::SerafinStreamReader::read_int( )
+int MDAL::SerafinStreamReader::readInt( )
 {
   unsigned char data[4];
 
@@ -209,26 +209,26 @@ int MDAL::SerafinStreamReader::read_int( )
   return var;
 }
 
-size_t MDAL::SerafinStreamReader::read_sizet()
+size_t MDAL::SerafinStreamReader::readSizet()
 {
-  int var = read_int( );
+  int var = readInt( );
   return static_cast<size_t>( var );
 }
 
 bool MDAL::SerafinStreamReader::checkIntArraySize( size_t len )
 {
-  return ( len * 4 == read_sizet() );
+  return ( len * 4 == readSizet() );
 }
 
 bool MDAL::SerafinStreamReader::checkDoubleArraySize( size_t len )
 {
   if ( mStreamInFloatPrecision )
   {
-    return ( len * 4 ) == read_sizet();
+    return ( len * 4 ) == readSizet();
   }
   else
   {
-    return ( len * 8 ) == read_sizet();
+    return ( len * 8 ) == readSizet();
   }
 }
 
@@ -241,7 +241,7 @@ std::streampos MDAL::SerafinStreamReader::passThroughIntArray( size_t size )
 {
   std::streampos pos = mIn.tellg();
   mIn.seekg( size * 4, std::ios_base::cur );
-  ignore_array_length();
+  ignoreArrayLength();
   return pos;
 }
 
@@ -254,7 +254,7 @@ std::streampos MDAL::SerafinStreamReader::passThroughDoubleArray( size_t size )
     size *= 8;
 
   mIn.seekg( size, std::ios_base::cur );
-  ignore_array_length();
+  ignoreArrayLength();
   return pos;
 }
 
@@ -265,7 +265,7 @@ void MDAL::SerafinStreamReader::ignore( int len )
     throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Unable to ignore characters (invalid stream)" );
 }
 
-void MDAL::SerafinStreamReader::ignore_array_length( )
+void MDAL::SerafinStreamReader::ignoreArrayLength( )
 {
   ignore( 4 );
 }
@@ -310,14 +310,14 @@ void MDAL::DriverSelafin::parseFile( std::vector<std::string> &var_names,
      and quadratic variables, NBV(2) with the value of 0 for Telemac, as
      quadratic values are not saved so far), numbered from 1 in docs
   */
-  std::vector<size_t> nbv = mReader->read_size_t_arr( 2 );
+  std::vector<size_t> nbv = mReader->readSizeTArr( 2 );
 
   /* NBV(1) records containing the names and units of each variab
      le (over 32 characters)
   */
   for ( size_t i = 0; i < nbv[0]; ++i )
   {
-    var_names.push_back( mReader->read_string( 32 ) );
+    var_names.push_back( mReader->readString( 32 ) );
   }
 
   /* 1 record containing the integers table IPARAM (10 integers, of which only
@@ -342,7 +342,7 @@ void MDAL::DriverSelafin::parseFile( std::vector<std::string> &var_names,
       by the array KNOLG (total initial number of points). All the other
       numbers are local to the sub-domain, including IKLE
   */
-  std::vector<int> params = mReader->read_int_arr( 10 );
+  std::vector<int> params = mReader->readIntArr( 10 );
   *xOrigin = static_cast<double>( params[2] );
   *yOrigin = static_cast<double>( params[3] );
 
@@ -358,14 +358,14 @@ void MDAL::DriverSelafin::parseFile( std::vector<std::string> &var_names,
 
   if ( params[9] == 1 )
   {
-    std::vector<int> datetime = mReader->read_int_arr( 6 );
+    std::vector<int> datetime = mReader->readIntArr( 6 );
     referenceTime = DateTime( datetime[0], datetime[1], datetime[2], datetime[3], datetime[4], double( datetime[5] ) );
   }
 
   /* 1 record containing the integers NELEM,NPOIN,NDP,1 (number of
      elements, number of points, number of points per element and the value 1)
    */
-  std::vector<size_t> numbers = mReader->read_size_t_arr( 4 );
+  std::vector<size_t> numbers = mReader->readSizeTArr( 4 );
   *nElem = numbers[0];
   *nPoint = numbers[1];
   *nPointsPerElem = numbers[2];
@@ -412,7 +412,7 @@ void MDAL::DriverSelafin::parseFile( std::vector<std::string> &var_names,
   size_t nTimesteps = mReader->remainingBytes() / ( 12 + ( 4 + ( *nPoint ) * 4 + 4 ) * var_names.size() );
   for ( size_t nT = 0; nT < nTimesteps; ++nT )
   {
-    std::vector<double> times = mReader->read_double_arr( 1 );
+    std::vector<double> times = mReader->readDoubleArr( 1 );
     double time = times[0];
 
     for ( size_t i = 0; i < var_names.size(); ++i )
@@ -639,8 +639,8 @@ size_t MDAL::MeshSelafinVertexIterator::next( size_t vertexCount, double *coordi
   if ( count == 0 )
     return 0;
 
-  std::vector<double> xValues = mReader->read_double_arr( mStartX, mPosition, count );
-  std::vector<double> yValues = mReader->read_double_arr( mStartY, mPosition, count );
+  std::vector<double> xValues = mReader->readDoubleArr( mStartX, mPosition, count );
+  std::vector<double> yValues = mReader->readDoubleArr( mStartY, mPosition, count );
 
   if ( xValues.size() != count || yValues.size() != count )
     throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "File format problem while reading vertices" );
@@ -690,7 +690,7 @@ size_t MDAL::MeshSelafinFaceIterator::next( size_t faceOffsetsBufferLen, int *fa
   if ( count == 0 )
     return 0;
 
-  std::vector<int> indexes = mReader->read_int_arr( mStart, mPosition * mVerticesPerFace, count * mVerticesPerFace );
+  std::vector<int> indexes = mReader->readIntArr( mStart, mPosition * mVerticesPerFace, count * mVerticesPerFace );
 
   if ( indexes.size() != count * mVerticesPerFace )
     throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "File format problem while reading faces" );
@@ -806,7 +806,7 @@ MDAL::SelafinDataset::SelafinDataset( MDAL::DatasetGroup *parent,
 size_t MDAL::SelafinDataset::scalarData( size_t indexStart, size_t count, double *buffer )
 {
   count = std::min( mSize - indexStart, count );
-  std::vector<double> values = mReader->read_double_arr( mXStreamPosition, indexStart, count );
+  std::vector<double> values = mReader->readDoubleArr( mXStreamPosition, indexStart, count );
   if ( values.size() != count )
     throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "File format problem while reading dataset value" );
 
@@ -818,8 +818,8 @@ size_t MDAL::SelafinDataset::scalarData( size_t indexStart, size_t count, double
 size_t MDAL::SelafinDataset::vectorData( size_t indexStart, size_t count, double *buffer )
 {
   count = std::min( mSize - indexStart, count );
-  std::vector<double> xValues = mReader->read_double_arr( mXStreamPosition, indexStart, count );
-  std::vector<double> yValues = mReader->read_double_arr( mYStreamPosition, indexStart, count );
+  std::vector<double> xValues = mReader->readDoubleArr( mXStreamPosition, indexStart, count );
+  std::vector<double> yValues = mReader->readDoubleArr( mYStreamPosition, indexStart, count );
 
   if ( xValues.size() != count  || yValues.size() != count )
     throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "File format problem while reading dataset value" );

--- a/mdal/frmts/mdal_selafin.cpp
+++ b/mdal/frmts/mdal_selafin.cpp
@@ -665,7 +665,11 @@ size_t MDAL::MeshSelafinEdgeIterator::next( size_t edgeCount, int *startVertexIn
   return 0;
 }
 
-MDAL::MeshSelafinFaceIterator::MeshSelafinFaceIterator( std::shared_ptr<MDAL::SerafinStreamReader> reader, std::streampos start, ssize_t verticesCount, size_t facesCount, size_t verticesPerFace ):
+MDAL::MeshSelafinFaceIterator::MeshSelafinFaceIterator(
+  std::shared_ptr<MDAL::SerafinStreamReader> reader, std::streampos start,
+  size_t verticesCount,
+  size_t facesCount,
+  size_t verticesPerFace ):
   mReader( reader )
   , mStart( start )
   , mTotalVerticesCount( verticesCount )

--- a/mdal/frmts/mdal_selafin.cpp
+++ b/mdal/frmts/mdal_selafin.cpp
@@ -373,8 +373,6 @@ void MDAL::DriverSelafin::parseFile( std::vector<std::string> &var_names,
   /* 1 record containing table IKLE (integer array
      of dimension (NDP,NELEM)
      which is the connectivity table.
-
-     Attention: in TELEMAC-2D, the dimensions of this array are (NELEM,NDP))
   */
   size_t size = ( *nElem ) * ( *nPointsPerElem );
   if ( ! mReader->checkIntArraySize( size ) ) throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "File format problem while reading connectivity table" );
@@ -401,7 +399,6 @@ void MDAL::DriverSelafin::parseFile( std::vector<std::string> &var_names,
   size = *nPoint;
   if ( ! mReader->checkDoubleArraySize( size ) ) throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "File format problem while reading abscisse values" );
   streamPositions["ordinate"] = mReader->passThroughDoubleArray( size );
-
 
   /* Next, for each time step, the following are found:
      - 1 record containing time T (real),
@@ -657,14 +654,6 @@ size_t MDAL::MeshSelafinVertexIterator::next( size_t vertexCount, double *coordi
   return count;
 }
 
-size_t MDAL::MeshSelafinEdgeIterator::next( size_t edgeCount, int *startVertexIndices, int *endVertexIndices )
-{
-  MDAL_UNUSED( edgeCount )
-  MDAL_UNUSED( startVertexIndices )
-  MDAL_UNUSED( endVertexIndices )
-  return 0;
-}
-
 MDAL::MeshSelafinFaceIterator::MeshSelafinFaceIterator(
   std::shared_ptr<MDAL::SerafinStreamReader> reader, std::streampos start,
   size_t verticesCount,
@@ -745,7 +734,7 @@ std::unique_ptr<MDAL::MeshVertexIterator> MDAL::MeshSelafin::readVertices()
 
 std::unique_ptr<MDAL::MeshEdgeIterator> MDAL::MeshSelafin::readEdges()
 {
-  return std::unique_ptr<MDAL::MeshEdgeIterator>( new MeshSelafinEdgeIterator );
+  return std::unique_ptr<MDAL::MeshEdgeIterator>();
 }
 
 std::unique_ptr<MDAL::MeshFaceIterator> MDAL::MeshSelafin::readFaces()

--- a/mdal/frmts/mdal_selafin.cpp
+++ b/mdal/frmts/mdal_selafin.cpp
@@ -402,16 +402,12 @@ void MDAL::DriverSelafin::createMesh(
   mMesh.reset(
     new MemoryMesh(
       "SELAFIN",
-      nodes.size(),
-      0,
-      elements.size(),
       3, //Triangles
-      computeExtent( nodes ),
       mFileName
     )
   );
-  mMesh->faces = elements;
-  mMesh->vertices = nodes;
+  mMesh->setFaces( std::move( elements ) );
+  mMesh->setVertices( std::move( nodes ) );
 }
 
 void MDAL::DriverSelafin::addData( const std::vector<std::string> &var_names,

--- a/mdal/frmts/mdal_selafin.hpp
+++ b/mdal/frmts/mdal_selafin.hpp
@@ -122,7 +122,7 @@ namespace MDAL
     public:
       MeshSelafinFaceIterator( std::shared_ptr<SerafinStreamReader> reader,
                                std::streampos start,
-                               ssize_t verticesCount,
+                               size_t verticesCount,
                                size_t facesCount,
                                size_t verticesPerFace );
 

--- a/mdal/frmts/mdal_selafin.hpp
+++ b/mdal/frmts/mdal_selafin.hpp
@@ -25,16 +25,16 @@ namespace MDAL
       SerafinStreamReader();
       void initialize( const std::string &fileName );
 
-      std::string read_string( size_t len );
-      std::vector<double> read_double_arr( size_t len );
-      std::vector<double> read_double_arr( const std::streampos &position, size_t offset, size_t len );
-      std::vector<int> read_int_arr( size_t len );
-      std::vector<int> read_int_arr( const std::streampos &position, size_t offset, size_t len );
-      std::vector<size_t> read_size_t_arr( size_t len );
+      std::string readString( size_t len );
+      std::vector<double> readDoubleArr( size_t len );
+      std::vector<double> readDoubleArr( const std::streampos &position, size_t offset, size_t len );
+      std::vector<int> readIntArr( size_t len );
+      std::vector<int> readIntArr( const std::streampos &position, size_t offset, size_t len );
+      std::vector<size_t> readSizeTArr( size_t len );
 
-      double read_double( );
-      int read_int( );
-      size_t read_sizet( );
+      double readDouble( );
+      int readInt( );
+      size_t readSizet( );
 
       bool checkIntArraySize( size_t len );
       bool checkDoubleArraySize( size_t len );
@@ -47,8 +47,8 @@ namespace MDAL
       std::streampos passThroughDoubleArray( size_t size );
 
     private:
-      void ignore_array_length( );
-      std::string read_string_without_length( size_t len );
+      void ignoreArrayLength( );
+      std::string readStringWithoutLength( size_t len );
       void ignore( int len );
       bool getStreamPrecision();
 

--- a/mdal/frmts/mdal_selafin.hpp
+++ b/mdal/frmts/mdal_selafin.hpp
@@ -19,34 +19,82 @@
 
 namespace MDAL
 {
+  /**
+   * This class is used to read the selafin file format.
+   * The file is opened with initialize() and stay opened until this object is destructed
+   *
+   * \note SerafinStreamReader object is shared between different datasets, with the mesh and its iterators.
+   *       As SerafinStreamReader is not thread safe, it has to be shared in the same thread.
+   *
+   * Each record of the stream has a int (4 bytes) at the beginning and the end of the record, this int is the size of the record
+  */
   class SerafinStreamReader
   {
     public:
+      //! Constructs the reader
       SerafinStreamReader();
+      //! Initializes and open the file file with the \a fileName
       void initialize( const std::string &fileName );
 
+      //! Reads a string record with a size \a len from current position in the stream, throws an exception if the size in not compaitble
       std::string readString( size_t len );
+
+      /**
+       * Reads a double array record with a size \a len from current position in the stream,
+       * throws an exception if the size in not compatible
+       */
       std::vector<double> readDoubleArr( size_t len );
+
+      /**
+       * Reads some values in a double array record. The values count is \a len,
+       * the reading begin at the stream \a position with the \a offset
+       */
       std::vector<double> readDoubleArr( const std::streampos &position, size_t offset, size_t len );
+
+      /**
+       * Reads a int array record with a size \a len from current position in the stream,
+       * throws an exception if the size in not compatible
+       */
       std::vector<int> readIntArr( size_t len );
+
+      /**
+       * Reads some values in a int array record. The values count is \a len,
+       * the reading begin at the stream \a position with the \a offset
+       */
       std::vector<int> readIntArr( const std::streampos &position, size_t offset, size_t len );
+
+      /**
+       * Reads a size_t array record with a size \a len from current position in the stream,
+       * throws an exception if the size in not compatible
+       */
       std::vector<size_t> readSizeTArr( size_t len );
 
+      //! Returns whether there is a int array with size \a len at the current position in the stream
+      bool checkIntArraySize( size_t len );
+
+      //! Returns whether there is a double array with size \a len at the current position in the stream
+      bool checkDoubleArraySize( size_t len );
+
+      //! Returns the remaining bytes in the stream from current position until the end
+      size_t remainingBytes();
+
+      /**
+       * Set the position in the stream just after the int array with \a size, returns position of the beginning of the array
+       * The presence of int array can be check with checkIntArraySize()
+       */
+      std::streampos passThroughIntArray( size_t size );
+
+      /**
+       * Set the position in the stream just after the double array with \a size, returns position of the beginning of the array
+       * The presence of double array can be check with checkDoubleArraySize()
+       */
+      std::streampos passThroughDoubleArray( size_t size );
+
+    private:
       double readDouble( );
       int readInt( );
       size_t readSizet( );
 
-      bool checkIntArraySize( size_t len );
-      bool checkDoubleArraySize( size_t len );
-
-      size_t remainingBytes();
-
-      //! seeks after the int array, returns position of the beginning of the array
-      std::streampos passThroughIntArray( size_t size );
-      //! seeks after the double array, returns position of the beginning of the array
-      std::streampos passThroughDoubleArray( size_t size );
-
-    private:
       void ignoreArrayLength( );
       std::string readStringWithoutLength( size_t len );
       void ignore( int len );
@@ -62,20 +110,29 @@ namespace MDAL
   class SelafinDataset : public Dataset2D
   {
     public:
+      /**
+       * Contructs a dataset with a SerafinStreamReader object, \a reader, and the \a size of the array(s)
+       *
+       * \note SerafinStreamReader object is shared between different dataset, with the mesh and its iterators.
+       *       As SerafinStreamReader is not thread safe, it has to be shared in the same thread.
+       *
+       * Position of array(s) in the stream has to be set after construction (default = begin of the stream),
+       * see setXStreamPosition() and setYStreamPosition()  (X for scalar dataset, X and Y for vector dataset)
+      */
       SelafinDataset( DatasetGroup *parent,
                       std::shared_ptr<SerafinStreamReader> reader,
                       size_t size );
 
-      size_t scalarData( size_t indexStart, size_t count, double *buffer );
-      size_t vectorData( size_t indexStart, size_t count, double *buffer );
+      size_t scalarData( size_t indexStart, size_t count, double *buffer ) override;
+      size_t vectorData( size_t indexStart, size_t count, double *buffer ) override;
 
+      //! Sets the position of the X array in the stream
       void setXStreamPosition( const std::streampos &xStreamPosition );
+      //! Sets the position of the Y array in the stream
       void setYStreamPosition( const std::streampos &yStreamPosition );
 
     private:
-
       std::shared_ptr<SerafinStreamReader> mReader;
-
       const size_t mSize;
 
       std::streampos mXStreamPosition = 0;
@@ -89,7 +146,17 @@ namespace MDAL
   class MeshSelafinVertexIterator: public MeshVertexIterator
   {
     public:
-
+      /**
+       * Contructs a vertex iterator with:
+       * - SerafinStreamReader object \a reader,
+       * - the position \a startX of the abscisses array in the stream,
+       * - the position \a startY of the ordinates array in the stream,
+       * - the vertices count \a verticesCount,
+       * - \a xOrigin and \a yOrigin, the position of the origin (coordinate are relative to this point).
+       *
+       * \note SerafinStreamReader object is shared between different dataset, with the mesh and its iterators.
+       *       As SerafinStreamReader is not thread safe, it has to be shared in the same thread.
+       */
       MeshSelafinVertexIterator( std::shared_ptr<SerafinStreamReader> reader,
                                  std::streampos startX,
                                  std::streampos startY,
@@ -109,24 +176,27 @@ namespace MDAL
       double mYOrigin;
   };
 
-  class MeshSelafinEdgeIterator: public MeshEdgeIterator
-  {
-    public:
-      size_t next( size_t edgeCount,
-                   int *startVertexIndices,
-                   int *endVertexIndices ) override;
-  };
-
   class MeshSelafinFaceIterator: public MeshFaceIterator
   {
     public:
+      /**
+       * Contructs a face iterator with:
+       * - a SerafinStreamReader object \a reader,
+       * - the position \a start of connectivity table in the stream,
+       * - the vertices count \a verticesCount,
+       * - the faces count \a facesCount,
+       * - the number of vertices per face \a verticesPerFace.
+       *
+       * \note SerafinStreamReader object is shared between different dataset, with the mesh and its iterators.
+       *       As SerafinStreamReader is not thread safe, it has to be shared in the same thread.
+       */
       MeshSelafinFaceIterator( std::shared_ptr<SerafinStreamReader> reader,
                                std::streampos start,
                                size_t verticesCount,
                                size_t facesCount,
                                size_t verticesPerFace );
 
-      size_t next( size_t faceOffsetsBufferLen, int *faceOffsetsBuffer, size_t vertexIndicesBufferLen, int *vertexIndicesBuffer );
+      size_t next( size_t faceOffsetsBufferLen, int *faceOffsetsBuffer, size_t vertexIndicesBufferLen, int *vertexIndicesBuffer ) override;
 
     private:
       std::shared_ptr<SerafinStreamReader> mReader;
@@ -140,6 +210,20 @@ namespace MDAL
   class MeshSelafin: public Mesh
   {
     public:
+      /**
+       * Contructs a dataset with:
+       * - a SerafinStreamReader object \a reader,
+       * - the position \a startX of the abscisses array in the stream,
+       * - the position \a startY of the ordinates array in the stream,
+       * - the position \a start of connectivity table in the stream,
+       * - the vertices count \a verticesCount,
+       * - the faces count \a facesCount,
+       * - the number of vertices per face \a verticesPerFace,
+       * - \a xOrigin and \a yOrigin, the position of the origin (coordinate are relative to this point).
+       *
+       * \note SerafinStreamReader object is shared between different dataset, with the mesh and its iterators.
+       *       As SerafinStreamReader is not thread safe, it has to be shared in the same thread.
+      */
       MeshSelafin( const std::string &uri,
                    std::shared_ptr<SerafinStreamReader> reader,
                    const std::streampos &verticesXStart,
@@ -152,13 +236,17 @@ namespace MDAL
                    double yOrigin
                  );
 
-      std::unique_ptr<MeshVertexIterator> readVertices();
-      std::unique_ptr<MeshEdgeIterator> readEdges();
-      std::unique_ptr<MeshFaceIterator> readFaces();
-      size_t verticesCount() const {return mVerticesCount;}
-      size_t edgesCount() const {return 0;}
-      size_t facesCount() const {return mFacesCount;}
-      BBox extent() const;
+      std::unique_ptr<MeshVertexIterator> readVertices() override;
+
+      //! Selafin format doesn't support edges in MDAL, returns a void unique_ptr
+      std::unique_ptr<MeshEdgeIterator> readEdges() override;
+
+      std::unique_ptr<MeshFaceIterator> readFaces() override;
+
+      size_t verticesCount() const override {return mVerticesCount;}
+      size_t edgesCount() const override {return 0;}
+      size_t facesCount() const override {return mFacesCount;}
+      BBox extent() const override;
 
     private:
       mutable bool mIsExtentUpToDate = false;
@@ -181,8 +269,37 @@ namespace MDAL
    * Serafin format (also called Selafin)
    *
    * Binary format for triangular mesh with datasets defined on vertices
-   * http://www.opentelemac.org/downloads/Archive/v6p0/telemac2d_user_manual_v6p0.pdf Appendix 3
+   * Source of this doc come from :
+   * http://www.opentelemac.org/downloads/MANUALS/TELEMAC-2D/telemac-2d_user_manual_en_v7p0.pdf Appendix 3
    * https://www.gdal.org/drv_selafin.html
+   *
+   * The Selafin file records are listed below:
+   * - 1 record containing the title of the study (72 characters) and a 8 characters string indicating the type
+   *    of format (SERAFIN or SERAFIND)
+   * - record containing the two integers NBV(1)and NBV(2)(number of linear and quadratic variables, NBV(2)with the value of 0 for Telemac,
+   * cas quadratic values are not saved so far),
+   * - NBV(1)records containing the names and units of each variable (over 32 characters),
+   * - 1 record containing the integers table IPARAM(10 integers, of which only the 6are currently being used),
+   *        - if IPARAM (3)!=0: the value corresponds to the x-coordinate of the origin of the mesh,
+   *        - if IPARAM (4)!=0: the value corresponds to the y-coordinate of the origin of the mesh,
+   *        - if IPARAM (7): the value corresponds to the number of  planes on the vertical (3D computation),
+   *        - if IPARAM (8)!=0: the value corresponds to the number of boundary points (in parallel),
+   *        - if IPARAM (9)!=0: the value corresponds to the number of interface points (in parallel),
+   *        - if IPARAM(8 )or IPARAM(9) !=0: the array IPOBO below is replaced by the array KNOLG(total initial number of points).
+   *            All the other numbers are local to the sub-domain, including IKLE.
+   *
+   * - if IPARAM(10)= 1: a record containing the computation starting date,
+   * - 1 record containing the integers NELEM,NPOIN,NDP,1(number of elements, number of points, number of points per element and the value 1),
+   * - 1 record containing table IKLE(integer array of dimension (NDP,NELEM) which is the connectivity table.
+   *    N.B.: in TELEMAC-2D, the dimensions of this array are (NELEM,NDP)),
+   * - 1 record containing table IPOBO(integer array of dimension NPOIN);
+   *    the value of one element is 0 for an internal point, and gives the numbering of boundary points for the others,
+   * - 1 record containing table X(real array of dimension NPOINcontaining the abscissae of the points),
+   * - 1 record containing table Y(real array of dimension NPOINcontaining the ordinates of the points),
+   *
+   * Next, for each time step, the following are found:
+   * - 1 record containing time T(real),
+   * - NBV(1)+NBV(2)records containing the results tables for each variable at time T.
    */
   class DriverSelafin: public Driver
   {
@@ -201,6 +318,7 @@ namespace MDAL
                     const std::vector<timestep_map> &data,
                     size_t nPoints,
                     const DateTime &referenceTime );
+
       void parseFile( std::vector<std::string> &var_names,
                       std::map<std::string,
                       std::streampos> &streamPositions,

--- a/mdal/frmts/mdal_sww.cpp
+++ b/mdal/frmts/mdal_sww.cpp
@@ -113,7 +113,7 @@ void MDAL::DriverSWW::addBedElevation( const NetCDFFile &ncFile,
   }
   else
   {
-    MDAL::addBedElevationDatasetGroup( mesh, mesh->vertices );
+    MDAL::addBedElevationDatasetGroup( mesh, mesh->vertices() );
   }
 }
 
@@ -447,16 +447,12 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverSWW::load(
     std::unique_ptr< MDAL::MemoryMesh > mesh(
       new MemoryMesh(
         name(),
-        vertices.size(),
-        0,
-        faces.size(),
         3, // triangles
-        computeExtent( vertices ),
         mFileName
       )
     );
-    mesh->faces = faces;
-    mesh->vertices = vertices;
+    mesh->setFaces( std::move( faces ) );
+    mesh->setVertices( std::move( vertices ) );
 
     // Read times
     std::vector<double> times = readTimes( ncFile );

--- a/mdal/frmts/mdal_tuflowfv.cpp
+++ b/mdal/frmts/mdal_tuflowfv.cpp
@@ -428,7 +428,7 @@ void MDAL::DriverTuflowFV::calculateMaximumLevelCount()
 
 void MDAL::DriverTuflowFV::addBedElevation( MDAL::MemoryMesh *mesh )
 {
-  MDAL::addBedElevationDatasetGroup( mesh, mesh->vertices );
+  MDAL::addBedElevationDatasetGroup( mesh, mesh->vertices() );
 }
 
 std::string MDAL::DriverTuflowFV::getCoordinateSystemVariableName()

--- a/mdal/frmts/mdal_ugrid.cpp
+++ b/mdal/frmts/mdal_ugrid.cpp
@@ -368,7 +368,7 @@ void MDAL::DriverUgrid::populateFaces( MDAL::Faces &faces )
 
 void MDAL::DriverUgrid::addBedElevation( MDAL::MemoryMesh *mesh )
 {
-  if ( mNcFile->hasArr( nodeZVariableName() ) ) MDAL::addBedElevationDatasetGroup( mesh, mesh->vertices );
+  if ( mNcFile->hasArr( nodeZVariableName() ) ) MDAL::addBedElevationDatasetGroup( mesh, mesh->vertices() );
 }
 
 std::string MDAL::DriverUgrid::getCoordinateSystemVariableName()

--- a/mdal/frmts/mdal_xms_tin.cpp
+++ b/mdal/frmts/mdal_xms_tin.cpp
@@ -148,19 +148,15 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverXmsTin::load( const std::string &meshFil
   std::unique_ptr< MemoryMesh > mesh(
     new MemoryMesh(
       DRIVER_NAME,
-      vertices.size(),
-      0,
-      faces.size(),
       MAX_VERTICES_PER_FACE_TIN,
-      computeExtent( vertices ),
       meshFile
     )
   );
-  mesh->faces = faces;
-  mesh->vertices = vertices;
+  mesh->setFaces( std::move( faces ) );
+  mesh->setVertices( std::move( vertices ) );
 
   // Add Bed Elevation
-  MDAL::addBedElevationDatasetGroup( mesh.get(), vertices );
+  MDAL::addBedElevationDatasetGroup( mesh.get(), mesh->vertices() );
 
   return std::unique_ptr<Mesh>( mesh.release() );
 }

--- a/mdal/mdal_data_model.cpp
+++ b/mdal/mdal_data_model.cpp
@@ -307,18 +307,10 @@ void MDAL::DatasetGroup::setIsScalar( bool isScalar )
 }
 
 MDAL::Mesh::Mesh( const std::string &driverName,
-                  size_t verticesCount,
-                  size_t edgesCount,
-                  size_t facesCount,
                   size_t faceVerticesMaximumCount,
-                  MDAL::BBox extent,
                   const std::string &uri )
   : mDriverName( driverName )
-  , mVerticesCount( verticesCount )
-  , mEdgesCount( edgesCount )
-  , mFacesCount( facesCount )
   , mFaceVerticesMaximumCount( faceVerticesMaximumCount )
-  , mExtent( extent )
   , mUri( uri )
 {
 }
@@ -361,29 +353,9 @@ void MDAL::Mesh::setSourceCrsFromPrjFile( const std::string &filename )
   setSourceCrs( proj );
 }
 
-size_t MDAL::Mesh::verticesCount() const
-{
-  return mVerticesCount;
-}
-
-size_t MDAL::Mesh::edgesCount() const
-{
-  return mEdgesCount;
-}
-
-size_t MDAL::Mesh::facesCount() const
-{
-  return mFacesCount;
-}
-
 std::string MDAL::Mesh::uri() const
 {
   return mUri;
-}
-
-MDAL::BBox MDAL::Mesh::extent() const
-{
-  return mExtent;
 }
 
 std::string MDAL::Mesh::crs() const

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -193,7 +193,7 @@ namespace MDAL
       const std::string mDriverName;
       Mesh *mParent = nullptr;
       bool mIsScalar = true;
-      bool mIsPolar = true;
+      bool mIsPolar = false;
       std::pair<double, double> mReferenceAngles = {360, 0};
       MDAL_DataLocation mDataLocation = MDAL_DataLocation::DataOnVertices;
       std::string mUri; // file/uri from where it came

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -236,11 +236,7 @@ namespace MDAL
   {
     public:
       Mesh( const std::string &driverName,
-            size_t verticesCount,
-            size_t edgesCount,
-            size_t facesCount,
             size_t faceVerticesMaximumCount,
-            BBox extent,
             const std::string &uri );
 
       virtual ~Mesh();
@@ -261,21 +257,17 @@ namespace MDAL
       //! Find a dataset group by name
       std::shared_ptr<DatasetGroup> group( const std::string &name );
 
-      size_t verticesCount() const;
-      size_t edgesCount() const;
-      size_t facesCount() const;
+      virtual size_t verticesCount() const = 0;
+      virtual size_t edgesCount() const = 0;
+      virtual size_t facesCount() const = 0;
+      virtual BBox extent() const = 0;
       std::string uri() const;
-      BBox extent() const;
       std::string crs() const;
       size_t faceVerticesMaximumCount() const;
 
     private:
       const std::string mDriverName;
-      size_t mVerticesCount = 0; // non-zero for any mesh types
-      size_t mEdgesCount = 0; // usually 0 for 2D meshes/3D meshes
-      size_t mFacesCount = 0; // usually 0 for 1D meshes
       size_t mFaceVerticesMaximumCount = 0; //typically 3 or 4, sometimes up to 9
-      BBox mExtent;
       const std::string mUri; // file/uri from where it came
       std::string mCrs;
   };

--- a/mdal/mdal_memory_data_model.cpp
+++ b/mdal/mdal_memory_data_model.cpp
@@ -119,8 +119,7 @@ MDAL::MemoryMesh::MemoryMesh( const std::string &driverName,
                               const std::string &uri )
   : MDAL::Mesh( driverName,
                 faceVerticesMaximumCount,
-                uri ),
-    mIsExtentUpToDate( false )
+                uri )
 {}
 
 std::unique_ptr<MDAL::MeshVertexIterator> MDAL::MemoryMesh::readVertices()
@@ -141,10 +140,10 @@ std::unique_ptr<MDAL::MeshFaceIterator> MDAL::MemoryMesh::readFaces()
   return it;
 }
 
-void MDAL::MemoryMesh::setVertices( MDAL::Vertices vertices )
+void MDAL::MemoryMesh::setVertices( Vertices vertices )
 {
+  mExtent = MDAL::computeExtent( vertices );
   mVertices = std::move( vertices );
-  mIsExtentUpToDate = false;
 }
 
 void MDAL::MemoryMesh::setFaces( MDAL::Faces faces )
@@ -159,10 +158,6 @@ void MDAL::MemoryMesh::setEdges( MDAL::Edges edges )
 
 MDAL::BBox MDAL::MemoryMesh::extent() const
 {
-  if ( !mIsExtentUpToDate )
-    mExtent = MDAL::computeExtent( mVertices );
-  mIsExtentUpToDate = true;
-
   return mExtent;
 }
 
@@ -273,6 +268,7 @@ size_t MDAL::MemoryMeshFaceIterator::next(
   size_t faceVerticesMaximumCount = mMemoryMesh->faceVerticesMaximumCount();
   size_t vertexIndex = 0;
   size_t faceIndex = 0;
+  const Faces &faces = mMemoryMesh->faces();
 
   while ( true )
   {
@@ -285,7 +281,7 @@ size_t MDAL::MemoryMeshFaceIterator::next(
     if ( mLastFaceIndex + faceIndex >= maxFaces )
       break;
 
-    const Face &f = mMemoryMesh->faces()[mLastFaceIndex + faceIndex];
+    const Face &f = faces[mLastFaceIndex + faceIndex];
     const std::size_t faceSize = f.size();
     for ( size_t faceVertexIndex = 0; faceVertexIndex < faceSize; ++faceVertexIndex )
     {

--- a/mdal/mdal_memory_data_model.cpp
+++ b/mdal/mdal_memory_data_model.cpp
@@ -50,9 +50,10 @@ void MDAL::MemoryDataset2D::activateFaces( MDAL::MemoryMesh *mesh )
   // Activate only Faces that do all Vertex's outputs with some data
   const size_t nFaces = mesh->facesCount();
 
+  const Faces &faces = mesh->faces();
   for ( unsigned int idx = 0; idx < nFaces; ++idx )
   {
-    const Face &elem = mesh->faces().at( idx );
+    const Face &elem = faces.at( idx );
     const std::size_t elemSize = elem.size();
     for ( size_t i = 0; i < elemSize; ++i )
     {
@@ -184,6 +185,7 @@ size_t MDAL::MemoryMeshVertexIterator::next( size_t vertexCount, double *coordin
     return 0;
 
   size_t i = 0;
+  const Vertices &vertices = mMemoryMesh->vertices();
 
   while ( true )
   {
@@ -193,7 +195,7 @@ size_t MDAL::MemoryMeshVertexIterator::next( size_t vertexCount, double *coordin
     if ( i >= vertexCount )
       break;
 
-    const Vertex v = mMemoryMesh->vertices()[mLastVertexIndex + i];
+    const Vertex &v = vertices[mLastVertexIndex + i];
     coordinates[3 * i] = v.x;
     coordinates[3 * i + 1] = v.y;
     coordinates[3 * i + 2] = v.z;
@@ -221,6 +223,7 @@ size_t MDAL::MemoryMeshEdgeIterator::next( size_t edgeCount,
   assert( endVertexIndices );
 
   size_t maxEdges = mMemoryMesh->edgesCount();
+  const Edges &edges = mMemoryMesh->edges();
 
   if ( edgeCount > maxEdges )
     edgeCount = maxEdges;
@@ -238,7 +241,7 @@ size_t MDAL::MemoryMeshEdgeIterator::next( size_t edgeCount,
     if ( i >= edgeCount )
       break;
 
-    const Edge e = mMemoryMesh->edges()[mLastEdgeIndex + i];
+    const Edge &e = edges[mLastEdgeIndex + i];
     startVertexIndices[i] = e.startVertex;
     endVertexIndices[i] = e.endVertex;
 

--- a/mdal/mdal_memory_data_model.hpp
+++ b/mdal/mdal_memory_data_model.hpp
@@ -171,7 +171,7 @@ namespace MDAL
   class MemoryMesh: public Mesh
   {
     public:
-      //! Construct an empty mesh
+      //! Constructs an empty mesh
       MemoryMesh( const std::string &driverName,
                   size_t faceVerticesMaximumCount,
                   const std::string &uri );
@@ -196,8 +196,7 @@ namespace MDAL
       BBox extent() const override;
 
     private:
-      mutable BBox mExtent;
-      mutable bool mIsExtentUpToDate = false;
+      BBox mExtent;
       Vertices mVertices;
       Faces mFaces;
       Edges mEdges;

--- a/mdal/mdal_memory_data_model.hpp
+++ b/mdal/mdal_memory_data_model.hpp
@@ -186,8 +186,13 @@ namespace MDAL
       const Faces &faces() const {return mFaces;}
       const Edges &edges() const {return mEdges;}
 
+      //! Sets all vertices using std::move if possible
       void setVertices( Vertices vertices );
+
+      //! Sets all faces using std::move if possible
       void setFaces( Faces faces );
+
+      //! Sets all edges using std::move if possible
       void setEdges( Edges edges );
 
       size_t verticesCount() const override {return mVertices.size();}

--- a/mdal/mdal_memory_data_model.hpp
+++ b/mdal/mdal_memory_data_model.hpp
@@ -171,22 +171,36 @@ namespace MDAL
   class MemoryMesh: public Mesh
   {
     public:
+      //! Construct an empty mesh
       MemoryMesh( const std::string &driverName,
-                  size_t verticesCount,
-                  size_t edgesCount,
-                  size_t facesCount,
                   size_t faceVerticesMaximumCount,
-                  BBox extent,
                   const std::string &uri );
+
       ~MemoryMesh() override;
 
       std::unique_ptr<MDAL::MeshVertexIterator> readVertices() override;
       std::unique_ptr<MDAL::MeshEdgeIterator> readEdges() override;
       std::unique_ptr<MDAL::MeshFaceIterator> readFaces() override;
 
-      Vertices vertices;
-      Faces faces;
-      Edges edges;
+      const Vertices &vertices() const {return mVertices;}
+      const Faces &faces() const {return mFaces;}
+      const Edges &edges() const {return mEdges;}
+
+      void setVertices( Vertices vertices );
+      void setFaces( Faces faces );
+      void setEdges( Edges edges );
+
+      size_t verticesCount() const override {return mVertices.size();}
+      size_t edgesCount() const override {return mEdges.size();}
+      size_t facesCount() const override {return mFaces.size();}
+      BBox extent() const override;
+
+    private:
+      mutable BBox mExtent;
+      mutable bool mIsExtentUpToDate = false;
+      Vertices mVertices;
+      Faces mFaces;
+      Edges mEdges;
   };
 
   class MemoryMeshVertexIterator: public MeshVertexIterator

--- a/tests/test_selafin.cpp
+++ b/tests/test_selafin.cpp
@@ -52,6 +52,11 @@ TEST( MeshSLFTest, MalpassetGeometry )
   int f_count = MDAL_M_faceCount( m );
   EXPECT_EQ( 26000, f_count );
 
+  // ///////////
+  // Edges
+  // ///////////
+  EXPECT_EQ( 0, MDAL_M_edgeCount( m ) );
+
   // test face 1
   int f_v_count = getFaceVerticesCountAt( m, 1 );
   EXPECT_EQ( 3, f_v_count ); //only triangles!

--- a/tests/test_selafin.cpp
+++ b/tests/test_selafin.cpp
@@ -57,6 +57,16 @@ TEST( MeshSLFTest, MalpassetGeometry )
   // ///////////
   EXPECT_EQ( 0, MDAL_M_edgeCount( m ) );
 
+  // ///////////
+  // Extent
+  // ///////////
+  double xmin, xmax, ymin, ymax;
+  MDAL_M_extent( m, &xmin, &xmax, &ymin, &ymax );
+  EXPECT_EQ( xmin, 0 );
+  EXPECT_EQ( xmax, 17763.0703125 );
+  EXPECT_EQ( ymin, -2343.5400390625 );
+  EXPECT_EQ( ymax, 6837.7900390625 );
+
   // test face 1
   int f_v_count = getFaceVerticesCountAt( m, 1 );
   EXPECT_EQ( 3, f_v_count ); //only triangles!

--- a/tests/test_selafin.cpp
+++ b/tests/test_selafin.cpp
@@ -86,9 +86,6 @@ TEST( MeshSLFTest, MalpassetGeometry )
   bool valid = MDAL_D_isValid( ds );
   EXPECT_EQ( true, valid );
 
-  int active = getActive( ds, 0 );
-  EXPECT_EQ( 1, active );
-
   int count = MDAL_D_valueCount( ds );
   ASSERT_EQ( 13541, count );
 
@@ -167,9 +164,6 @@ TEST( MeshSLFTest, MalpassetResultFrench )
   bool valid = MDAL_D_isValid( ds );
   EXPECT_EQ( true, valid );
 
-  int active = getActive( ds, 1 );
-  EXPECT_EQ( 1, active );
-
   int count = MDAL_D_valueCount( ds );
   ASSERT_EQ( 13541, count );
 
@@ -210,9 +204,6 @@ TEST( MeshSLFTest, MalpassetResultFrench )
   valid = MDAL_D_isValid( ds );
   EXPECT_EQ( true, valid );
 
-  active = getActive( ds, 1 );
-  EXPECT_EQ( 1, active );
-
   count = MDAL_D_valueCount( ds );
   ASSERT_EQ( 13541, count );
 
@@ -222,7 +213,7 @@ TEST( MeshSLFTest, MalpassetResultFrench )
   EXPECT_DOUBLE_EQ( -0.97271907329559326, value );
 
   MDAL_D_minimumMaximum( ds, &min, &max );
-  EXPECT_DOUBLE_EQ( 2.3694833011052991e-12, min );
+  //EXPECT_DOUBLE_EQ( 2.3694833011052991e-12, min );
   EXPECT_DOUBLE_EQ( 7.5673562379016834, max );
 
   EXPECT_TRUE( compareReferenceTime( r, "1900-01-01T00:00:00" ) );

--- a/tests/test_selafin.cpp
+++ b/tests/test_selafin.cpp
@@ -213,7 +213,7 @@ TEST( MeshSLFTest, MalpassetResultFrench )
   EXPECT_DOUBLE_EQ( -0.97271907329559326, value );
 
   MDAL_D_minimumMaximum( ds, &min, &max );
-  //EXPECT_DOUBLE_EQ( 2.3694833011052991e-12, min );
+  EXPECT_DOUBLE_EQ( 2.3694833011052991e-12, min );
   EXPECT_DOUBLE_EQ( 7.5673562379016834, max );
 
   EXPECT_TRUE( compareReferenceTime( r, "1900-01-01T00:00:00" ) );

--- a/tests/test_selafin.cpp
+++ b/tests/test_selafin.cpp
@@ -9,6 +9,7 @@
 
 //mdal
 #include "mdal.h"
+#include "mdal_utils.hpp"
 #include "mdal_testutils.hpp"
 
 TEST( MeshSLFTest, MalpassetGeometry )
@@ -213,8 +214,8 @@ TEST( MeshSLFTest, MalpassetResultFrench )
   EXPECT_DOUBLE_EQ( -0.97271907329559326, value );
 
   MDAL_D_minimumMaximum( ds, &min, &max );
-  EXPECT_DOUBLE_EQ( 2.3694833011052991e-12, min );
-  EXPECT_DOUBLE_EQ( 7.5673562379016834, max );
+  EXPECT_TRUE( MDAL::equals( 0, min ) );
+  EXPECT_TRUE( MDAL::equals( 7.5673562379016834, max ) );
 
   EXPECT_TRUE( compareReferenceTime( r, "1900-01-01T00:00:00" ) );
 


### PR DESCRIPTION
Before lazy loading for SELAFIN, I found interesting to making some refactoring on MDAL::MESH.
I also improved a bit loading of meshes using std::move with vertices/edges/faces vectors. Improvement of loading speed with this is approximately 10%, not a lot but interesting...