### PR TITLE
[WIP] support writting with active flag

### DIFF
--- a/mdal/frmts/mdal_binary_dat.cpp
+++ b/mdal/frmts/mdal_binary_dat.cpp
@@ -464,7 +464,7 @@ bool MDAL::DriverBinaryDat::persist( MDAL::DatasetGroup *group )
       // Write status flags
       for ( size_t i = 0; i < elemCount; i++ )
       {
-        bool active = static_cast<bool>( dataset->active( i ) );
+        bool active = dataset->supportsActiveFlag() ? static_cast<bool>( dataset->active( i ) ) : true;
         writeRawData( out, reinterpret_cast< const char * >( &active ), 1 );
       }
     }

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -794,12 +794,6 @@ MDAL_DatasetH MDAL_G_addDataset( MDAL_DatasetGroupH group, double time, const do
     return nullptr;
   }
 
-  if ( active && g->dataLocation() != MDAL_DataLocation::DataOnVertices )
-  {
-    MDAL::Log::error( MDAL_Status::Err_IncompatibleDataset, "Active flag is only supported on datasets with data on vertices" );
-    return nullptr;
-  }
-
   const size_t index = g->datasets.size();
   MDAL::RelativeTimestamp t( time, MDAL::RelativeTimestamp::hours );
   dr->createDataset( g,

--- a/mdal/mdal_memory_data_model.cpp
+++ b/mdal/mdal_memory_data_model.cpp
@@ -19,7 +19,6 @@ MDAL::MemoryDataset2D::MemoryDataset2D( MDAL::DatasetGroup *grp, bool hasActiveF
   setSupportsActiveFlag( hasActiveFlag );
   if ( hasActiveFlag )
   {
-    assert( grp->dataLocation() == MDAL_DataLocation::DataOnVertices );
     mActive = std::vector<int>( mesh()->facesCount(), 1 );
   }
 }


### PR DESCRIPTION
Working on saving dataset on QGIS side, it appeared that it was no possible to write datasets on faces when those datasets has active flag. 
Maybe I missed something, but I do not understand why? Maybe an old logic that is not valid anymore?
For example TUFLOWFV read data on face with active flag.
This PR allows writing dataset on faces with active flag.