### PR TITLE
change for writing memory dataset from QGIS

### DIFF
--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -530,6 +530,12 @@ MDAL_EXPORT const char *MDAL_G_referenceTime( MDAL_DatasetGroupH group );
  */
 MDAL_EXPORT bool MDAL_G_isTemporal( MDAL_DatasetGroupH group );
 
+/**
+ * Returns dataset metadata key
+ * not thread-safe and valid only till next call
+ */
+MDAL_EXPORT const char *MDAL_G_uri( MDAL_DatasetGroupH group);
+
 ///////////////////////////////////////////////////////////////////////////////////////
 /// DATASETS
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -164,6 +164,14 @@ MDAL_EXPORT bool MDAL_DR_meshLoadCapability( MDAL_DriverH driver );
 MDAL_EXPORT bool MDAL_DR_writeDatasetsCapability( MDAL_DriverH driver, MDAL_DataLocation location );
 
 /**
+ * Returns the file suffix used to write datasets on file
+ * not thread-safe and valid only till next call
+ *
+ * \since MDAL 0.7.0
+ */
+MDAL_EXPORT const char *MDAL_DR_writeDatasetsSuffix( MDAL_DriverH driver );
+
+/**
  * Returns whether driver has capability to save mesh
  */
 MDAL_EXPORT bool MDAL_DR_saveMeshCapability( MDAL_DriverH driver );
@@ -531,10 +539,12 @@ MDAL_EXPORT const char *MDAL_G_referenceTime( MDAL_DatasetGroupH group );
 MDAL_EXPORT bool MDAL_G_isTemporal( MDAL_DatasetGroupH group );
 
 /**
- * Returns dataset metadata key
+ * Returns dataset group uri
  * not thread-safe and valid only till next call
+ *
+ * \since MDAL 0.7.0
  */
-MDAL_EXPORT const char *MDAL_G_uri( MDAL_DatasetGroupH group);
+MDAL_EXPORT const char *MDAL_G_uri( MDAL_DatasetGroupH group );
 
 ///////////////////////////////////////////////////////////////////////////////////////
 /// DATASETS

--- a/mdal/frmts/mdal_ascii_dat.cpp
+++ b/mdal/frmts/mdal_ascii_dat.cpp
@@ -563,3 +563,8 @@ bool MDAL::DriverAsciiDat::persist( MDAL::DatasetGroup *group )
 
   return false;
 }
+
+std::string MDAL::DriverAsciiDat::writeDatasetOnFileSuffix() const
+{
+  return "dat";
+}

--- a/mdal/frmts/mdal_ascii_dat.cpp
+++ b/mdal/frmts/mdal_ascii_dat.cpp
@@ -485,7 +485,9 @@ bool MDAL::DriverAsciiDat::persist( MDAL::DatasetGroup *group )
   if ( !MDAL::contains( uri, "_els" ) && group->dataLocation() != MDAL_DataLocation::DataOnVertices )
   {
     // Should contain _els in name for edges/faces dataset but it does not
-    uri.insert( uri.size() - 4, "_els" );
+    int pos = uri.size() - 4;
+    uri.insert( std::max( 0, pos ), "_els" );
+    group->replaceUri( uri );
   }
 
   if ( ( mesh->facesCount() > 0 ) && ( mesh->edgesCount() > 0 ) )

--- a/mdal/frmts/mdal_ascii_dat.hpp
+++ b/mdal/frmts/mdal_ascii_dat.hpp
@@ -59,6 +59,8 @@ namespace MDAL
       void load( const std::string &datFile, Mesh *mesh ) override;
       bool persist( DatasetGroup *group ) override;
 
+      std::string writeDatasetOnFileSuffix() const override;
+
     private:
       bool canReadOldFormat( const std::string &line ) const;
       bool canReadNewFormat( const std::string &line ) const;

--- a/mdal/frmts/mdal_binary_dat.cpp
+++ b/mdal/frmts/mdal_binary_dat.cpp
@@ -491,3 +491,8 @@ bool MDAL::DriverBinaryDat::persist( MDAL::DatasetGroup *group )
 
   return false;
 }
+
+std::string MDAL::DriverBinaryDat::writeDatasetOnFileSuffix() const
+{
+  return "dat";
+}

--- a/mdal/frmts/mdal_binary_dat.hpp
+++ b/mdal/frmts/mdal_binary_dat.hpp
@@ -31,6 +31,8 @@ namespace MDAL
       void load( const std::string &datFile, Mesh *mesh ) override;
       bool persist( DatasetGroup *group ) override;
 
+      std::string writeDatasetOnFileSuffix() const override;
+
     private:
       bool readVertexTimestep( const Mesh *mesh,
                                std::shared_ptr<DatasetGroup> group,

--- a/mdal/frmts/mdal_driver.cpp
+++ b/mdal/frmts/mdal_driver.cpp
@@ -36,6 +36,12 @@ std::string MDAL::Driver::filters() const
   return mFilters;
 }
 
+std::string MDAL::Driver::writeDatasetOnFileSuffix() const
+{
+
+  return std::string();
+}
+
 bool MDAL::Driver::hasCapability( MDAL::Capability capability ) const
 {
   return capability == ( mCapabilityFlags & capability );

--- a/mdal/frmts/mdal_driver.hpp
+++ b/mdal/frmts/mdal_driver.hpp
@@ -42,6 +42,8 @@ namespace MDAL
       bool hasCapability( Capability capability ) const;
       bool hasWriteDatasetCapability( MDAL_DataLocation location ) const;
 
+      virtual std::string writeDatasetOnFileSuffix() const;
+
       virtual bool canReadMesh( const std::string &uri );
       virtual bool canReadDatasets( const std::string &uri );
 

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -1190,3 +1190,14 @@ const char *MDAL_G_uri( MDAL_DatasetGroupH group )
   MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
   return _return_str( g->uri() );
 }
+const char *MDAL_DR_writeDatasetsSuffix( MDAL_DriverH driver )
+{
+  if ( !driver )
+  {
+    MDAL::Log::error( MDAL_Status::Err_MissingDriver, "Driver is not valid (null)" );
+    return EMPTY_STR;
+  }
+
+  MDAL::Driver *d = static_cast< MDAL::Driver * >( driver );
+  return _return_str( d->writeDatasetOnFileSuffix() );
+}

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -1179,3 +1179,14 @@ bool MDAL_G_isTemporal( MDAL_DatasetGroupH group )
   MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
   return g->datasets.size() > 1;
 }
+
+const char *MDAL_G_uri( MDAL_DatasetGroupH group )
+{
+  if ( !group )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleDataset, "Dataset Group is not valid (null)" );
+    return EMPTY_STR;
+  }
+  MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
+  return _return_str( g->uri() );
+}

--- a/mdal/mdal_data_model.cpp
+++ b/mdal/mdal_data_model.cpp
@@ -208,6 +208,11 @@ std::string MDAL::DatasetGroup::uri() const
   return mUri;
 }
 
+void MDAL::DatasetGroup::replaceUri( std::string uri )
+{
+  mUri = uri;
+}
+
 MDAL::Statistics MDAL::DatasetGroup::statistics() const
 {
   return mStatistics;

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -166,6 +166,7 @@ namespace MDAL
       void setDataLocation( MDAL_DataLocation dataLocation );
 
       std::string uri() const;
+      void replaceUri( std::string uri );
 
       Statistics statistics() const;
       void setStatistics( const Statistics &statistics );

--- a/tests/test_ascii_dat.cpp
+++ b/tests/test_ascii_dat.cpp
@@ -832,6 +832,8 @@ TEST( MeshAsciiDatTest, WriteScalarVertexTest )
 
     MDAL_DriverH driver = MDAL_driverFromName( "ASCII_DAT" );
     ASSERT_NE( driver, nullptr );
+    const char *suffix = MDAL_DR_writeDatasetsSuffix( driver );
+    EXPECT_EQ( std::string( "dat" ), std::string( suffix ) );
     ASSERT_TRUE( MDAL_DR_writeDatasetsCapability( driver, MDAL_DataLocation::DataOnVertices ) );
 
     MDAL_DatasetGroupH g = MDAL_M_addDatasetGroup(

--- a/tests/test_binary_dat.cpp
+++ b/tests/test_binary_dat.cpp
@@ -187,6 +187,8 @@ TEST( MeshBinaryDatTest, WriteScalarTest )
 
     MDAL_DriverH driver = MDAL_driverFromName( "BINARY_DAT" );
     ASSERT_NE( driver, nullptr );
+    const char *suffix = MDAL_DR_writeDatasetsSuffix( driver );
+    EXPECT_EQ( std::string( "dat" ), std::string( suffix ) );
     ASSERT_TRUE( MDAL_DR_writeDatasetsCapability( driver, MDAL_DataLocation::DataOnVertices ) );
     ASSERT_FALSE( MDAL_DR_writeDatasetsCapability( driver, MDAL_DataLocation::DataOnFaces ) );
     ASSERT_FALSE( MDAL_DR_writeDatasetsCapability( driver, MDAL_DataLocation::DataOnVolumes ) );

--- a/tests/test_flo2d.cpp
+++ b/tests/test_flo2d.cpp
@@ -214,6 +214,8 @@ TEST( MeshFlo2dTest, WriteBarnHDF5_Append )
     MDAL_MeshH m = MDAL_LoadMesh( pathOrig.c_str() );
     ASSERT_NE( m, nullptr );
     MDAL_DriverH driver = MDAL_driverFromName( "FLO2D" );
+    const char *suffix = MDAL_DR_writeDatasetsSuffix( driver );
+    EXPECT_EQ( std::string( "" ), std::string( suffix ) );
     ASSERT_NE( driver, nullptr );
     ASSERT_EQ( 5, MDAL_M_datasetGroupCount( m ) );
 


### PR DESCRIPTION
when writing data on faces with ASCII_DAT, if the uri doesn't contain "_els", MDAL change the uri. Then in QGIS, the dataset group is not retrieved because the uri has change.
With this PR, if the dataset group uri is changed if needed and exposed to the API to allows QGIS to register the good uri in `mExtraDatasetUris`.

For QGIS 3.14, not a big issue. The dataset is not loaded when first repoening, but the user can reload it, and everything will be ok after, even after close/repoen.

**EDIT:**
Add also the possibility to return file suffix for writing dataset
