### PR TITLE
Squashing Some Warnings

### DIFF
--- a/mdal/frmts/mdal_ascii_dat.cpp
+++ b/mdal/frmts/mdal_ascii_dat.cpp
@@ -485,7 +485,7 @@ bool MDAL::DriverAsciiDat::persist( MDAL::DatasetGroup *group )
   if ( !MDAL::contains( uri, "_els" ) && group->dataLocation() != MDAL_DataLocation::DataOnVertices )
   {
     // Should contain _els in name for edges/faces dataset but it does not
-    int pos = uri.size() - 4;
+    int pos = MDAL::toInt( uri.size() ) - 4;
     uri.insert( std::max( 0, pos ), "_els" );
     group->replaceUri( uri );
   }

--- a/mdal/frmts/mdal_flo2d.cpp
+++ b/mdal/frmts/mdal_flo2d.cpp
@@ -833,8 +833,8 @@ void MDAL::DriverFlo2D::createMesh2d( const std::vector<CellCenter> &cells, cons
 
     for ( size_t position = 0; position < 4; ++position )
     {
-      size_t xPos=0;
-      size_t yPos=0;
+      size_t xPos = 0;
+      size_t yPos = 0;
 
       switch ( position )
       {

--- a/mdal/frmts/mdal_flo2d.cpp
+++ b/mdal/frmts/mdal_flo2d.cpp
@@ -144,8 +144,8 @@ void MDAL::DriverFlo2D::parseCHANBANKFile( const std::string &datFileName,
     {
       throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Error while loading CHANBANK file, wrong lineparts count (2)" );
     }
-    int leftBank = MDAL::toSizeT( lineParts[0] ) - 1;  //numbered from 1
-    int rightBank = MDAL::toSizeT( lineParts[1] ) - 1;
+    int leftBank = MDAL::toInt( MDAL::toSizeT( lineParts[0] ) ) - 1;  //numbered from 1
+    int rightBank = MDAL::toInt( MDAL::toSizeT( lineParts[1] ) ) - 1;
 
     std::map<size_t, size_t>::const_iterator it = cellIdToVertices.find( rightBank );
     if ( it != cellIdToVertices.end() )
@@ -197,7 +197,7 @@ void MDAL::DriverFlo2D::parseCHANFile( const std::string &datFileName, const std
       {
         throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Error while loading CHAN file, wrong chanel element line" );
       }
-      int currentCellId = MDAL::toSizeT( lineParts[1] ) - 1;
+      int currentCellId = MDAL::toInt( MDAL::toSizeT( lineParts[1] ) ) - 1;
       if ( previousCellId >= 0 )
       {
         std::map<size_t, size_t>::const_iterator it1 = cellIdToVertices.find( previousCellId );
@@ -818,8 +818,8 @@ void MDAL::DriverFlo2D::createMesh2d( const std::vector<CellCenter> &cells, cons
                      cellCenterExtent.minY - half_cell_size,
                      cellCenterExtent.maxY + half_cell_size );
 
-  size_t width = ( vertexExtent.maxX - vertexExtent.minX ) / cell_size + 1;
-  size_t heigh = ( vertexExtent.maxY - vertexExtent.minY ) / cell_size + 1;
+  size_t width = MDAL::toSizeT( ( vertexExtent.maxX - vertexExtent.minX ) / cell_size + 1 );
+  size_t heigh = MDAL::toSizeT( ( vertexExtent.maxY - vertexExtent.minY ) / cell_size + 1 );
   std::vector<std::vector<size_t>> vertexGrid( width, std::vector<size_t>( heigh, INVALID_INDEX ) );
 
   Vertices vertices;
@@ -828,13 +828,13 @@ void MDAL::DriverFlo2D::createMesh2d( const std::vector<CellCenter> &cells, cons
   {
     Face &e = faces[i];
 
-    size_t xVertexIdx = ( cells[i].x - vertexExtent.minX ) / cell_size;
-    size_t yVertexIdx = ( cells[i].y - vertexExtent.minY ) / cell_size;
+    size_t xVertexIdx = MDAL::toSizeT( ( cells[i].x - vertexExtent.minX ) / cell_size );
+    size_t yVertexIdx = MDAL::toSizeT( ( cells[i].y - vertexExtent.minY ) / cell_size );
 
     for ( size_t position = 0; position < 4; ++position )
     {
-      size_t xPos;
-      size_t yPos;
+      size_t xPos=0;
+      size_t yPos=0;
 
       switch ( position )
       {

--- a/mdal/frmts/mdal_selafin.cpp
+++ b/mdal/frmts/mdal_selafin.cpp
@@ -863,7 +863,7 @@ size_t MDAL::MeshSelafinFaceIterator::next( size_t faceOffsetsBufferLen, int *fa
         throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "File format problem while reading faces" );
       vertexIndicesBuffer[vertexLocalIndex + j] = indexes[j + i * verticesPerFace] - 1;
     }
-    vertexLocalIndex += verticesPerFace;
+    vertexLocalIndex += MDAL::toInt( verticesPerFace );
     faceOffsetsBuffer[i] = vertexLocalIndex;
   }
 
@@ -936,9 +936,9 @@ static void writeInt( std::ofstream &file, int i )
 
 static void writeStringRecord( std::ofstream &file, const std::string &str )
 {
-  writeInt( file, str.size() );
+  writeInt( file, MDAL::toInt( str.size() ) );
   file.write( str.data(), str.size() );
-  writeInt( file, str.size() );
+  writeInt( file, MDAL::toInt( str.size() ) );
 }
 
 template<typename T>
@@ -1011,9 +1011,9 @@ void MDAL::DriverSelafin::save( const std::string &uri, MDAL::Mesh *mesh )
   size_t verticesCount = mesh->verticesCount();
   size_t facesCount = mesh->facesCount();
   std::vector<int> elem( 4 );
-  elem[0] = facesCount;
-  elem[1] = verticesCount;
-  elem[2] = verticesPerFace;
+  elem[0] = MDAL::toInt( facesCount );
+  elem[1] = MDAL::toInt( verticesCount );
+  elem[2] = MDAL::toInt( verticesPerFace );
   elem[3] = 1;
   writeValueArrayRecord( file, elem );
 
@@ -1022,7 +1022,7 @@ void MDAL::DriverSelafin::save( const std::string &uri, MDAL::Mesh *mesh )
   std::vector<int> faceOffsetBuffer( bufferSize );
   std::unique_ptr<MeshFaceIterator> faceIter = mesh->readFaces();
   size_t count = 0;
-  writeInt( file, facesCount * verticesPerFace * 4 );
+  writeInt( file, MDAL::toInt( facesCount * verticesPerFace * 4 ) );
   do
   {
     std::vector<int> inkle( bufferSize * verticesPerFace );
@@ -1034,7 +1034,7 @@ void MDAL::DriverSelafin::save( const std::string &uri, MDAL::Mesh *mesh )
     writeValueArray( file, inkle );
   }
   while ( count != 0 );
-  writeInt( file, facesCount * verticesPerFace * 4 );
+  writeInt( file, MDAL::toInt( facesCount * verticesPerFace * 4 ) );
 
   // IPOBO filled with 0
   writeValueArrayRecord( file, std::vector<int>( verticesCount, 0 ) );
@@ -1077,9 +1077,9 @@ static void writeScalarDataset( std::ofstream &file, MDAL::Dataset *dataset, boo
 {
   size_t valuesCount = dataset->valuesCount();
   size_t bufferSize = BUFFER_SIZE;
-  int count = 0;
-  int indexStart = 0;
-  writeInt( file, valuesCount * ( isFloat ? 4 : 8 ) );
+  size_t count = 0;
+  size_t indexStart = 0;
+  writeInt( file, MDAL::toInt( valuesCount * ( isFloat ? 4 : 8 ) ) );
   do
   {
     std::vector<double> values( bufferSize );
@@ -1088,8 +1088,8 @@ static void writeScalarDataset( std::ofstream &file, MDAL::Dataset *dataset, boo
     if ( isFloat )
     {
       std::vector<float> floatValues( count );
-      for ( int i = 0; i < count; ++i )
-        floatValues[i] = values[i];
+      for ( int i = 0; i < MDAL::toInt( count ); ++i )
+        floatValues[i] = static_cast<float>( values[i] );
       writeValueArray( file, floatValues );
     }
     else
@@ -1098,7 +1098,7 @@ static void writeScalarDataset( std::ofstream &file, MDAL::Dataset *dataset, boo
     indexStart += count;
   }
   while ( count != 0 );
-  writeInt( file, valuesCount * ( isFloat ? 4 : 8 ) );
+  writeInt( file, MDAL::toInt( valuesCount * ( isFloat ? 4 : 8 ) ) );
 }
 
 template<typename T>
@@ -1109,17 +1109,17 @@ static void writeVectorDataset( std::ofstream &file, MDAL::Dataset *dataset )
   std::vector<T> valuesX( valuesCount );
   std::vector<T> valuesY( valuesCount );
   size_t bufferSize = BUFFER_SIZE;
-  int count = 0;
-  int indexStart = 0;
+  size_t count = 0;
+  size_t indexStart = 0;
   do
   {
     std::vector<double> values( bufferSize * 2 );
     count = dataset->vectorData( indexStart, bufferSize, values.data() );
     values.resize( count * 2 );
-    for ( int i = 0; i < count; ++i )
+    for ( int i = 0; i < MDAL::toInt( count ); ++i )
     {
-      valuesX[indexStart + i] = values[i * 2];
-      valuesY[indexStart + i] = values[i * 2 + 1];
+      valuesX[indexStart + i] = static_cast< T >( values[i * 2] );
+      valuesY[indexStart + i] = static_cast< T >( values[i * 2 + 1] );
     }
     indexStart += count;
   }
@@ -1224,24 +1224,24 @@ bool MDAL::SelafinFile::addDatasetGroup( MDAL::DatasetGroup *datasetGroup )
   writeValueArrayRecord( out, std::vector<int> {int( mFacesCount ), int( mVerticesCount ), int( mVerticesPerFace ), 1} );
 
   //IKLE
-  writeInt( out, mFacesCount * mVerticesPerFace * 4 );
+  writeInt( out, MDAL::toInt( mFacesCount * mVerticesPerFace * 4 ) );
   streamToStream( out, mIn, mConnectivityStreamPosition, mFacesCount * mVerticesPerFace * 4, BUFFER_SIZE );
-  writeInt( out, mFacesCount * mVerticesPerFace * 4 );
+  writeInt( out, MDAL::toInt( mFacesCount * mVerticesPerFace * 4 ) );
   //vertices
 
   //IPOBO
-  writeInt( out, mVerticesCount * 4 );
+  writeInt( out, MDAL::toInt( mVerticesCount * 4 ) );
   streamToStream( out, mIn, mIPOBOStreamPosition, mVerticesCount * 4, BUFFER_SIZE );
-  writeInt( out, mVerticesCount * 4 );
+  writeInt( out, MDAL::toInt( mVerticesCount * 4 ) );
 
   //X Vertices
-  writeInt( out, mVerticesCount * realSize );
+  writeInt( out, MDAL::toInt( mVerticesCount * realSize ) );
   streamToStream( out, mIn, mXStreamPosition, mVerticesCount * realSize, BUFFER_SIZE );
-  writeInt( out, mVerticesCount * realSize );
+  writeInt( out, MDAL::toInt( mVerticesCount * realSize ) );
   //Y Vertices
-  writeInt( out, mVerticesCount * realSize );
+  writeInt( out, MDAL::toInt( mVerticesCount * realSize ) );
   streamToStream( out, mIn, mYStreamPosition, mVerticesCount * realSize, BUFFER_SIZE );
-  writeInt( out, mVerticesCount * realSize );
+  writeInt( out, MDAL::toInt( mVerticesCount * realSize ) );
 
   // Write datasets
   for ( size_t nT = 0; nT < mTimeSteps.size(); nT++ )
@@ -1249,7 +1249,7 @@ bool MDAL::SelafinFile::addDatasetGroup( MDAL::DatasetGroup *datasetGroup )
     // Time step
     if ( mStreamInFloatPrecision )
     {
-      std::vector<float> time( 1, mTimeSteps.at( nT ).value( RelativeTimestamp::seconds ) );
+      std::vector<float> time( 1, static_cast<float>( mTimeSteps.at( nT ).value( RelativeTimestamp::seconds ) ) );
       writeValueArrayRecord( out, time );
     }
     else
@@ -1261,9 +1261,9 @@ bool MDAL::SelafinFile::addDatasetGroup( MDAL::DatasetGroup *datasetGroup )
     // First, prexisting datasets from the original file
     for ( int i = 0; i < nbv[0] - addedVariable; ++i )
     {
-      writeInt( out, mVerticesCount * realSize );
+      writeInt( out, MDAL::toInt( mVerticesCount * realSize ) );
       streamToStream( out, mIn, mVariableStreamPosition[i][nT], realSize * mVerticesCount, BUFFER_SIZE );
-      writeInt( out, mVerticesCount * realSize );
+      writeInt( out, MDAL::toInt( mVerticesCount * realSize ) );
     }
 
     // Then, new datasets from the new dataset group

--- a/mdal/frmts/mdal_ugrid.cpp
+++ b/mdal/frmts/mdal_ugrid.cpp
@@ -315,8 +315,8 @@ void MDAL::DriverUgrid::populateEdges( MDAL::Edges &edges )
   for ( size_t i = 0; i < edgesCount; ++i )
   {
 
-    int startEdgeIx = i * 2;
-    int endEdgeIx = i * 2 + 1;
+    int startEdgeIx = MDAL::toInt( i ) * 2;
+    int endEdgeIx = MDAL::toInt( i ) * 2 + 1;
 
     edges[i].startVertex = edgeNodesIdxs[startEdgeIx] - startIndex;
     edges[i].endVertex = edgeNodesIdxs[endEdgeIx] - startIndex;

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -31,7 +31,7 @@ namespace MDAL
     double maxY = -std::numeric_limits<double>::max();
   };
 
-  typedef struct
+  typedef struct StatisticsType
   {
     double minimum = std::numeric_limits<double>::quiet_NaN();
     double maximum = std::numeric_limits<double>::quiet_NaN();

--- a/mdal/mdal_memory_data_model.cpp
+++ b/mdal/mdal_memory_data_model.cpp
@@ -308,8 +308,8 @@ size_t MDAL::MemoryMeshEdgeIterator::next( size_t edgeCount,
       break;
 
     const Edge &e = edges[mLastEdgeIndex + i];
-    startVertexIndices[i] = e.startVertex;
-    endVertexIndices[i] = e.endVertex;
+    startVertexIndices[i] = MDAL::toInt(e.startVertex);
+    endVertexIndices[i] = MDAL::toInt(e.endVertex);
 
     ++i;
   }

--- a/mdal/mdal_memory_data_model.cpp
+++ b/mdal/mdal_memory_data_model.cpp
@@ -308,8 +308,8 @@ size_t MDAL::MemoryMeshEdgeIterator::next( size_t edgeCount,
       break;
 
     const Edge &e = edges[mLastEdgeIndex + i];
-    startVertexIndices[i] = MDAL::toInt(e.startVertex);
-    endVertexIndices[i] = MDAL::toInt(e.endVertex);
+    startVertexIndices[i] = MDAL::toInt( e.startVertex );
+    endVertexIndices[i] = MDAL::toInt( e.endVertex );
 
     ++i;
   }

--- a/mdal/mdal_memory_data_model.hpp
+++ b/mdal/mdal_memory_data_model.hpp
@@ -19,7 +19,7 @@ namespace MDAL
 {
   class MemoryMesh;
 
-  typedef struct
+  typedef struct VertexType
   {
     double x = std::numeric_limits<double>::quiet_NaN();
     double y = std::numeric_limits<double>::quiet_NaN();

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -121,7 +121,7 @@ size_t MDAL::toSizeT( const char &str )
 
 size_t MDAL::toSizeT( const double value )
 {
-  return static_cast<size_t>(value);
+  return static_cast<size_t>( value );
 }
 
 int MDAL::toInt( const size_t value )

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -119,6 +119,18 @@ size_t MDAL::toSizeT( const char &str )
   return static_cast< size_t >( i );
 }
 
+int MDAL::toInt( const size_t value )
+{
+  if ( value > std::numeric_limits<int>::max() )
+    throw std::runtime_error( "Invalid cast" );
+  return static_cast< int >( value );
+}
+
+double MDAL::toDouble( const size_t value )
+{
+  return static_cast< double >( value );
+}
+
 double MDAL::toDouble( const std::string &str )
 {
   return atof( str.c_str() );

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -119,6 +119,11 @@ size_t MDAL::toSizeT( const char &str )
   return static_cast< size_t >( i );
 }
 
+size_t MDAL::toSizeT( const double value )
+{
+  return static_cast<size_t>(value);
+}
+
 int MDAL::toInt( const size_t value )
 {
   if ( value > std::numeric_limits<int>::max() )

--- a/mdal/mdal_utils.hpp
+++ b/mdal/mdal_utils.hpp
@@ -75,8 +75,11 @@ namespace MDAL
   /** Return 0 if not possible to convert */
   size_t toSizeT( const std::string &str );
   size_t toSizeT( const char &str );
+  size_t toSizeT( const double value );
   int toInt( const std::string &str );
+  int toInt( const size_t value );
   double toDouble( const std::string &str );
+  double toDouble( const size_t value );
   bool toBool( const std::string &str );
 
   //! Returns the string with a adapted format to coordinate


### PR DESCRIPTION
I have been doing a lot of compiling recently and there were a lot of warnings on the latest version of VS and Xcode during compiling. - mostly to do with :

- anonymous structs - see [here for the ms version](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5208?view=vs-2019) although Xcode was complaining as well

> So - I have given names to a couple of anonymous structs.

- implicit conversions to and from size_t which is a reasonable warning since there are potentials to lose data

> So - I have added some methods in mdal_utils and made the casts explicit with some error checking