### PR TITLE
fix hecras velocity/shear stress

### DIFF
--- a/mdal/frmts/mdal_hec2d.cpp
+++ b/mdal/frmts/mdal_hec2d.cpp
@@ -202,21 +202,6 @@ static std::vector<MDAL::RelativeTimestamp> readTimes( const HdfFile &hdfFile )
   return convertTimeData( times, dataTimeUnits );
 }
 
-static std::vector<int> readFace2Cells( const HdfFile &hdfFile, const std::string &flowAreaName, size_t *nFaces )
-{
-  // First read face to node mapping
-  HdfGroup gGeom = openHdfGroup( hdfFile, "Geometry" );
-  HdfGroup gGeom2DFlowAreas = openHdfGroup( gGeom, "2D Flow Areas" );
-  HdfGroup gArea = openHdfGroup( gGeom2DFlowAreas, flowAreaName );
-  HdfDataset dsFace2Cells = openHdfDataset( gArea, "Faces Cell Indexes" );
-
-  std::vector<hsize_t> fdims = dsFace2Cells.dims();
-  std::vector<int> face2Cells = dsFace2Cells.readArrayInt(); //2x nFaces
-
-  *nFaces = fdims[0];
-  return face2Cells;
-}
-
 void MDAL::DriverHec2D::readFaceOutput( const HdfFile &hdfFile,
                                         const HdfGroup &rootGroup,
                                         const std::vector<size_t> &areaElemStartIndex,
@@ -235,7 +220,7 @@ void MDAL::DriverHec2D::readFaceOutput( const HdfFile &hdfFile,
                                           datasetName
                                         );
   group->setDataLocation( MDAL_DataLocation::DataOnFaces );
-  group->setIsScalar( true );
+  group->setIsScalar( false );
   group->setReferenceTime( referenceTime );
 
   std::vector<std::shared_ptr<MDAL::MemoryDataset2D>> datasets;
@@ -253,34 +238,99 @@ void MDAL::DriverHec2D::readFaceOutput( const HdfFile &hdfFile,
   {
     std::string flowAreaName = flowAreaNames[nArea];
 
-    size_t nFaces;
-    std::vector<int> face2Cells = readFace2Cells( hdfFile, flowAreaName, &nFaces );
-
     HdfGroup gFlowAreaRes = openHdfGroup( rootGroup, flowAreaName );
     HdfDataset dsVals = openHdfDataset( gFlowAreaRes, rawDatasetName );
     std::vector<float> vals = dsVals.readArray();
+
+    HdfGroup gGeom = openHdfGroup( hdfFile, "Geometry" );
+    HdfGroup gGeom2DFlowAreas = openHdfGroup( gGeom, "2D Flow Areas" );
+    HdfGroup gArea = openHdfGroup( gGeom2DFlowAreas, flowAreaName );
+    HdfDataset dsCellFaceInfo = openHdfDataset( gArea, "Cells Face and Orientation Info" );
+    std::vector<hsize_t> celldims = dsCellFaceInfo.dims();
+    std::vector<int> cellFaceInfo = dsCellFaceInfo.readArrayInt();
+
+    HdfDataset dsCellFaceOrValues = openHdfDataset( gArea, "Cells Face and Orientation Values" );
+    std::vector<int> cellFaceOrValues = dsCellFaceOrValues.readArrayInt();
+
+    HdfDataset dsFacePointIndex = openHdfDataset( gArea, "Faces FacePoint Indexes" );
+    std::vector<hsize_t> fdims = dsFacePointIndex.dims();
+    size_t nFaces = static_cast<size_t>( fdims[0] );
+    std::vector<int> facePointIndex = dsFacePointIndex.readArrayInt();
+
+    HdfDataset dsCoords = openHdfDataset( gArea, "FacePoints Coordinate" );
+    std::vector<hsize_t> cdims = dsCoords.dims();
+    std::vector<double> coords = dsCoords.readArrayDouble(); //2xnNodes matrix in array
 
     for ( size_t tidx = 0; tidx < times.size(); ++tidx )
     {
       std::shared_ptr<MDAL::MemoryDataset2D> dataset = datasets[tidx];
       double *values = dataset->values();
 
-      for ( size_t i = 0; i < nFaces; ++i )
+      for ( size_t cell_idx = 0; cell_idx < celldims.at( 0 ); ++cell_idx )
       {
-        size_t idx = tidx * nFaces + i;
-        double val = static_cast<double>( vals[idx] ); // This is value on face!
-
-        if ( !std::isnan( val ) && fabs( val ) > eps ) //not nan and not 0
+        size_t cell_mdal_idx = cell_idx + areaElemStartIndex[nArea];
+        double valx = 0;
+        double valy = 0;
+        size_t consideredValueCount = 0;
+        size_t firstPosition = static_cast<size_t>( cellFaceInfo[cell_idx * 2] );
+        size_t faceCount = static_cast<size_t>( cellFaceInfo[cell_idx * 2 + 1] );
+        for ( size_t f = 0; f < faceCount; ++f )
         {
-          for ( size_t c = 0; c < 2; ++c )
+          //get face indexes
+          size_t faceIndex1 = static_cast<size_t>( cellFaceOrValues[( firstPosition + f ) * 2] );
+          size_t faceIndex2 = static_cast<size_t>( cellFaceOrValues[( firstPosition + ( f + 1 ) % faceCount ) * 2] );
+          double val1 = static_cast<double>( vals[faceIndex1 + tidx * nFaces] );
+          double val2 = static_cast<double>( vals[faceIndex2 + tidx * nFaces] );
+          if ( std::isnan( val1 ) || std::isnan( val2 ) )
+            continue;
+
+          size_t indexPoint11 = facePointIndex[faceIndex1 * 2];
+          size_t indexPoint12 = facePointIndex[faceIndex1 * 2 + 1];
+          size_t indexPoint21 = facePointIndex[faceIndex2 * 2];
+          size_t indexPoint22 = facePointIndex[faceIndex2 * 2 + 1];
+          bool commonIndex = ( indexPoint11 == indexPoint21 ||
+                               indexPoint11 == indexPoint22 ||
+                               indexPoint12 == indexPoint21 ||
+                               indexPoint12 == indexPoint22 );
+          if ( !commonIndex )
           {
-            size_t cell_idx = static_cast<size_t>( face2Cells[2 * i + c] ) + areaElemStartIndex[nArea];
-            // Take just maximum
-            if ( std::isnan( values[cell_idx] ) || values[cell_idx] < val )
-            {
-              values[cell_idx] = val;
-            }
+            // should not happen, but better to prevent
+            continue;
           }
+
+          double dx1 = coords[indexPoint11 * 2] - coords[indexPoint12 * 2];
+          double dy1 = coords[indexPoint11 * 2 + 1] - coords[indexPoint12 * 2 + 1];
+          double dx2 = coords[indexPoint21 * 2] - coords[indexPoint22 * 2];
+          double dy2 = coords[indexPoint21 * 2 + 1] - coords[indexPoint22 * 2 + 1];
+          double l1 = sqrt( dx1 * dx1 + dy1 * dy1 );
+          double l2 = sqrt( dx2 * dx2 + dy2 * dy2 );
+          if ( l1 == 0 || l2 == 0 )
+          {
+            continue;
+          }
+          double nx1 =   -dy1 / l1;
+          double ny1 =  dx1 / l1;
+          double nx2 =   -dy2 / l2;
+          double ny2 =  dx2 / l2;
+
+          double deter = nx1 * ny2 - nx2 * ny1;
+          if ( deter == 0 ) //colinear face, forbidden by hecras, but better to prevent
+            continue;
+          valx += ( ny2 * val1 - ny1 * val2 ) / deter;
+          valy += ( nx1 * val2 - nx2 * val1 ) / deter;
+          consideredValueCount++;
+        }
+        if ( consideredValueCount != 0 )
+        {
+          valx /= consideredValueCount;
+          valy /= consideredValueCount;
+          values[cell_mdal_idx * 2] = valx;
+          values[cell_mdal_idx * 2 + 1] = valy;
+        }
+        else
+        {
+          values[cell_mdal_idx * 2] = std::numeric_limits<double>::quiet_NaN();
+          values[cell_mdal_idx * 2 + 1] = std::numeric_limits<double>::quiet_NaN();
         }
       }
     }
@@ -302,15 +352,15 @@ void MDAL::DriverHec2D::readFaceResults( const HdfFile &hdfFile,
   // UNSTEADY
   HdfGroup flowGroup = get2DFlowAreasGroup( hdfFile, "Unsteady Time Series" );
   MDAL::DateTime referenceDateTime = readReferenceDateTime( hdfFile );
-  readFaceOutput( hdfFile, flowGroup, areaElemStartIndex, flowAreaNames, "Face Shear Stress", "Face Shear Stress", mTimes, referenceDateTime );
-  readFaceOutput( hdfFile, flowGroup, areaElemStartIndex, flowAreaNames, "Face Velocity", "Face Velocity", mTimes, referenceDateTime );
+  readFaceOutput( hdfFile, flowGroup, areaElemStartIndex, flowAreaNames, "Face Shear Stress", "Shear Stress", mTimes, referenceDateTime );
+  readFaceOutput( hdfFile, flowGroup, areaElemStartIndex, flowAreaNames, "Face Velocity", "Velocity", mTimes, referenceDateTime );
 
   // SUMMARY
   flowGroup = get2DFlowAreasGroup( hdfFile, "Summary Output" );
   std::vector<MDAL::RelativeTimestamp> dummyTimes( 1, MDAL::RelativeTimestamp() );
 
-  readFaceOutput( hdfFile, flowGroup, areaElemStartIndex, flowAreaNames, "Maximum Face Shear Stress", "Face Shear Stress/Maximums", dummyTimes, referenceDateTime );
-  readFaceOutput( hdfFile, flowGroup, areaElemStartIndex, flowAreaNames, "Maximum Face Velocity", "Face Velocity/Maximums", dummyTimes, referenceDateTime );
+  readFaceOutput( hdfFile, flowGroup, areaElemStartIndex, flowAreaNames, "Maximum Face Shear Stress", "Shear Stress/Maximums", dummyTimes, referenceDateTime );
+  readFaceOutput( hdfFile, flowGroup, areaElemStartIndex, flowAreaNames, "Maximum Face Velocity", "Velocity/Maximums", dummyTimes, referenceDateTime );
 }
 
 

--- a/tests/test_hec2d.cpp
+++ b/tests/test_hec2d.cpp
@@ -10,6 +10,7 @@
 
 //mdal
 #include "mdal.h"
+#include "mdal_utils.hpp"
 #include "mdal_testutils.hpp"
 
 TEST( MeshHec2dTest, simpleArea )
@@ -143,6 +144,49 @@ TEST( MeshHec2dTest, simpleArea )
   EXPECT_TRUE( compareDurationInHours( 0, time ) );
 
   EXPECT_TRUE( compareReferenceTime( g, "1899-12-30T00:00:00" ) );
+
+  // ///////////
+  // Vector Dataset
+  // ///////////
+  g = MDAL_M_datasetGroup( m, 5 );
+  ASSERT_NE( g, nullptr );
+
+  meta_count = MDAL_G_metadataCount( g );
+  ASSERT_EQ( 1, meta_count );
+
+  name = MDAL_G_name( g );
+  EXPECT_EQ( std::string( "Velocity" ), std::string( name ) );
+
+  scalar = MDAL_G_hasScalarData( g );
+  EXPECT_EQ( false, scalar );
+
+  dataLocation = MDAL_G_dataLocation( g );
+  EXPECT_EQ( dataLocation, MDAL_DataLocation::DataOnFaces );
+
+  ASSERT_EQ( 41, MDAL_G_datasetCount( g ) );
+  ds = MDAL_G_dataset( g, 35 );
+  ASSERT_NE( ds, nullptr );
+
+  valid = MDAL_D_isValid( ds );
+  EXPECT_EQ( true, valid );
+
+  EXPECT_FALSE( MDAL_D_hasActiveFlagCapability( ds ) );
+
+  count = MDAL_D_valueCount( ds );
+  ASSERT_EQ( 851, count );
+
+  value = getValueX( ds, 15 );
+  EXPECT_TRUE( MDAL::equals( -0.044146, value, 0.000001 ) );
+  value = getValueY( ds, 15 );
+  EXPECT_TRUE( MDAL::equals( 0.0001003014, value, 0.00000001 ) );
+
+  MDAL_D_minimumMaximum( ds, &min, &max );
+  EXPECT_TRUE( MDAL::equals( 7.3807e-5, min, 0.000001 ) );
+  EXPECT_TRUE( MDAL::equals( 0.0452122, max, 0.000001 ) );
+
+  MDAL_G_minimumMaximum( g, &min, &max );
+  EXPECT_DOUBLE_EQ( 0, min );
+  EXPECT_TRUE( MDAL::equals( 0.3837422465, max, 0.000001 ) );
 
   MDAL_CloseMesh( m );
 }


### PR DESCRIPTION
Affter playing a bit with hecras model and loading in QGIS, I've seen that velocity was not the same in hecras and QGIS.
Indeed, in hdf file, the velocity (and sheer stress) is quite tricky : the values are the values of vector (velocity or shear stress) projected on the normal of faces (that are  edges of the mdal faces). Confusing and not the same as the real value...
So, the real values need to reconstructed to obtain a vector value.

This PR allows to reconstruct the real values as vector, so hecras format support now velocity (and shear stress) as vector value.

I think it could be good to backport this to 0.7.1 to have this fix with the future LTR of QGIS.
