### PR TITLE
hecras: fix version 6.0 and wet/dry faces

### DIFF
--- a/mdal/frmts/mdal_hec2d.cpp
+++ b/mdal/frmts/mdal_hec2d.cpp
@@ -237,7 +237,16 @@ void MDAL::DriverHec2D::readFaceOutput( const HdfFile &hdfFile,
     std::string flowAreaName = flowAreaNames[nArea];
 
     HdfGroup gFlowAreaRes = openHdfGroup( rootGroup, flowAreaName );
-    HdfDataset dsVals = openHdfDataset( gFlowAreaRes, rawDatasetName );
+    HdfDataset dsVals;
+    try
+    {
+      dsVals = openHdfDataset( gFlowAreaRes, rawDatasetName );
+    }
+    catch ( MDAL::Error )
+    {
+      return;
+    }
+
     std::vector<float> vals = dsVals.readArray();
 
     HdfGroup gGeom = openHdfGroup( hdfFile, "Geometry" );
@@ -334,7 +343,7 @@ void MDAL::DriverHec2D::readFaceOutput( const HdfFile &hdfFile,
     }
   }
 
-  for ( auto dataset : datasets )
+  for ( auto &dataset : datasets )
   {
     dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
     group->datasets.push_back( dataset );
@@ -371,7 +380,7 @@ std::shared_ptr<MDAL::MemoryDataset2D> MDAL::DriverHec2D::readElemOutput( const 
     std::shared_ptr<MDAL::MemoryDataset2D> bed_elevation,
     const DateTime &referenceTime )
 {
-  double eps = std::numeric_limits<double>::min();
+  double eps = static_cast<double>( std::numeric_limits<float>::epsilon() ); //hecras use float so comparison needs to use float epsilon
 
   std::shared_ptr<DatasetGroup> group = std::make_shared< DatasetGroup >(
                                           name(),
@@ -398,7 +407,16 @@ std::shared_ptr<MDAL::MemoryDataset2D> MDAL::DriverHec2D::readElemOutput( const 
     std::string flowAreaName = flowAreaNames[nArea];
     HdfGroup gFlowAreaRes = openHdfGroup( rootGroup, flowAreaName );
 
-    HdfDataset dsVals = openHdfDataset( gFlowAreaRes, rawDatasetName );
+    HdfDataset dsVals;
+    try
+    {
+      dsVals = openHdfDataset( gFlowAreaRes, rawDatasetName );
+    }
+    catch ( MDAL::Error )
+    {
+      return nullptr;
+    }
+
     std::vector<float> vals = dsVals.readArray();
 
     for ( size_t tidx = 0; tidx < times.size(); ++tidx )
@@ -410,7 +428,7 @@ std::shared_ptr<MDAL::MemoryDataset2D> MDAL::DriverHec2D::readElemOutput( const 
       {
         size_t idx = tidx * nAreaElements + i;
         size_t eInx = areaElemStartIndex[nArea] + i;
-        double val = static_cast<double>( vals[idx] );
+        double val =  static_cast<double>( vals[idx] );
         if ( !std::isnan( val ) )
         {
           if ( !bed_elevation )
@@ -431,7 +449,7 @@ std::shared_ptr<MDAL::MemoryDataset2D> MDAL::DriverHec2D::readElemOutput( const 
             {
               assert( bed_elevation );
               double bed_elev = bed_elevation->scalarValue( eInx );
-              if ( std::isnan( bed_elev ) || fabs( bed_elev - val ) > eps ) // change from bed elevation
+              if ( std::isnan( bed_elev ) || fabs( val - bed_elev ) > ( val + bed_elev )*eps )  // change from bed elevation
               {
                 values[eInx] = val;
               }
@@ -442,7 +460,7 @@ std::shared_ptr<MDAL::MemoryDataset2D> MDAL::DriverHec2D::readElemOutput( const 
     }
   }
 
-  for ( auto dataset : datasets )
+  for ( auto &dataset : datasets )
   {
     dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
     group->datasets.push_back( dataset );

--- a/mdal/frmts/mdal_hec2d.cpp
+++ b/mdal/frmts/mdal_hec2d.cpp
@@ -479,16 +479,20 @@ std::shared_ptr<MDAL::MemoryDataset2D> MDAL::DriverHec2D::readBedElevation(
   std::vector<MDAL::RelativeTimestamp> times( 1 );
   DateTime referenceTime;
 
-  return readElemOutput(
-           gGeom2DFlowAreas,
-           areaElemStartIndex,
-           flowAreaNames,
-           "Cells Minimum Elevation",
-           "Bed Elevation",
-           times,
-           std::shared_ptr<MDAL::MemoryDataset2D>(),
-           referenceTime
-         );
+  std::shared_ptr<MDAL::MemoryDataset2D> bedElevation = readElemOutput(
+        gGeom2DFlowAreas,
+        areaElemStartIndex,
+        flowAreaNames,
+        "Cells Minimum Elevation",
+        "Bed Elevation",
+        times,
+        std::shared_ptr<MDAL::MemoryDataset2D>(),
+        referenceTime
+      );
+
+  if ( ! bedElevation ) throw MDAL::Error( MDAL_Status::Err_InvalidData, "Unable to read bed elevation values" );
+
+  return bedElevation;
 }
 
 void MDAL::DriverHec2D::readElemResults(

--- a/tests/test_hec2d.cpp
+++ b/tests/test_hec2d.cpp
@@ -392,6 +392,9 @@ TEST( MeshHec2dTest, model_505 )
   count = MDAL_D_valueCount( ds );
   ASSERT_EQ( 73, count );
 
+  value = getValue( ds, 10 );
+  EXPECT_TRUE( std::isnan( value ) ); //dry face
+
   value = getValue( ds, 50 );
   EXPECT_TRUE( MDAL::equals( 34.785, value, 0.001 ) );
 

--- a/tests/test_hec2d.cpp
+++ b/tests/test_hec2d.cpp
@@ -392,8 +392,8 @@ TEST( MeshHec2dTest, model_505 )
   count = MDAL_D_valueCount( ds );
   ASSERT_EQ( 73, count );
 
-  value = getValue( ds, 10 );
-  EXPECT_DOUBLE_EQ( 33.000003814697266, value );
+  value = getValue( ds, 50 );
+  EXPECT_TRUE( MDAL::equals( 34.785, value, 0.001 ) );
 
   double min, max;
   MDAL_D_minimumMaximum( ds, &min, &max );
@@ -408,6 +408,111 @@ TEST( MeshHec2dTest, model_505 )
   EXPECT_TRUE( compareDurationInHours( 0.083333335816860199, time ) );
 
   EXPECT_TRUE( compareReferenceTime( g, "2018-01-01T00:00:00" ) );
+
+  MDAL_CloseMesh( m );
+}
+
+TEST( MeshHec2dTest, hec_6_0 )
+{
+  std::string path = test_file( "/hec2d/2d_6.0/Prueba.p01.hdf" );
+  EXPECT_EQ( MDAL_MeshNames( path.c_str() ), "HEC2D:\"" + path + "\"" );
+  MDAL_MeshH m = MDAL_LoadMesh( path.c_str() );
+  ASSERT_NE( m, nullptr );
+
+  const char *projection = MDAL_M_projection( m );
+  EXPECT_EQ( std::string( projection ), std::string( "PROJCS[\"ETRS89 / UTM zone 30N\",GEOGCS[\"ETRS89\",DATUM[\"D_ETRS_1989\",SPHEROID[\"GRS_1980\",6378137,298.257222101]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.017453292519943295]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-3],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1]]" ) );
+  // ///////////
+  // Vertices
+  // ///////////
+  int v_count = MDAL_M_vertexCount( m );
+  EXPECT_EQ( v_count, 4287 );
+
+  // ///////////
+  // Faces
+  // ///////////
+  int f_count = MDAL_M_faceCount( m );
+  EXPECT_EQ( 4403, f_count );
+
+  // ///////////
+  // Dataset groups
+  // ///////////
+
+  ASSERT_EQ( 5, MDAL_M_datasetGroupCount( m ) );
+
+  // Bed Elevation
+  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, 0 );
+  ASSERT_NE( g, nullptr );
+
+  int meta_count = MDAL_G_metadataCount( g );
+  ASSERT_EQ( 1, meta_count );
+
+  const char *name = MDAL_G_name( g );
+  EXPECT_EQ( std::string( "Bed Elevation" ), std::string( name ) );
+
+  bool scalar = MDAL_G_hasScalarData( g );
+  EXPECT_EQ( true, scalar );
+
+  MDAL_DataLocation dataLocation = MDAL_G_dataLocation( g );
+  EXPECT_EQ( dataLocation, MDAL_DataLocation::DataOnFaces );
+
+  ASSERT_EQ( 1, MDAL_G_datasetCount( g ) );
+  MDAL_DatasetH ds = MDAL_G_dataset( g, 0 );
+  ASSERT_NE( ds, nullptr );
+
+  bool valid = MDAL_D_isValid( ds );
+  EXPECT_EQ( true, valid );
+
+  EXPECT_FALSE( MDAL_D_hasActiveFlagCapability( ds ) );
+
+  int count = MDAL_D_valueCount( ds );
+  ASSERT_EQ( 4403, count );
+
+  double value = getValue( ds, 0 );
+  EXPECT_TRUE( MDAL::equals( 812.59869, value, 0.001 ) );
+
+  double min, max;
+  MDAL_D_minimumMaximum( ds, &min, &max );
+  EXPECT_TRUE( MDAL::equals( 802.0603, min, 0.001 ) );
+  EXPECT_TRUE( MDAL::equals( 907.402, max, 0.001 ) );
+
+  g = MDAL_M_datasetGroup( m, 1 );
+  ASSERT_NE( g, nullptr );
+
+  meta_count = MDAL_G_metadataCount( g );
+  ASSERT_EQ( 1, meta_count );
+
+  name = MDAL_G_name( g );
+  EXPECT_EQ( std::string( "Water Surface" ), std::string( name ) );
+
+  scalar = MDAL_G_hasScalarData( g );
+  EXPECT_EQ( true, scalar );
+
+  dataLocation = MDAL_G_dataLocation( g );
+  EXPECT_EQ( dataLocation, MDAL_DataLocation::DataOnFaces );
+
+  ASSERT_EQ( 361, MDAL_G_datasetCount( g ) );
+  ds = MDAL_G_dataset( g, 200 );
+  ASSERT_NE( ds, nullptr );
+
+  valid = MDAL_D_isValid( ds );
+  EXPECT_EQ( true, valid );
+
+  EXPECT_FALSE( MDAL_D_hasActiveFlagCapability( ds ) );
+
+  count = MDAL_D_valueCount( ds );
+  ASSERT_EQ( 4403, count );
+
+  value = getValue( ds, 10 );
+  EXPECT_TRUE( MDAL::equals( 807.006, value, 0.001 ) );
+
+  MDAL_D_minimumMaximum( ds, &min, &max );
+  EXPECT_TRUE( MDAL::equals( 806.957, min, 0.001 ) );
+  EXPECT_TRUE( MDAL::equals( 909.976, max, 0.001 ) );
+
+  double time = MDAL_D_time( ds );
+  EXPECT_TRUE( compareDurationInHours( 0.5555555555555556, time ) );
+
+  EXPECT_TRUE( compareReferenceTime( g, "2020-12-23T00:00:00" ) );
 
   MDAL_CloseMesh( m );
 }


### PR DESCRIPTION
fix #333 
New format  is very similar but the dataset group are not exactly the same (Depth and shear stress are now optional)

There are also optional dataset groups that are not yet supported by MDAL.

This PR fix also the comparison for wet/dry faces.