### PR TITLE
Docs : Fix typo in docs and add UPM package

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -30,12 +30,21 @@ MDAL can be installed as a stand-alone package (i.e. outside of QGIS) using `con
 The package can installed by running :
 
 ::
-conda install -c conda-forge mdal
+
+    conda install -c conda-forge mdal
 
 
 This package provides the MDAL ABI through the mdal shared object( i.e. mdal.dll, libmdal.dylib or libmdal.so) and the mdalinfo CLI.
 
 .. note:: A friendly note about versions. The conda package is usually targetted at the latest version of GDAL on conda-forge. This is usually a later version than used by QGIS. Therefore, there may be some subtle differences in behaviour when loading e.g. GRIB files.
+
+UPM Installation
+++++++++++++++++
+
+There is also a community supported Unity Package Manager (UPM) package for MDAL to allow MDAL to be used in Unity based projects. This builds on top of the Conda package.
+
+https://openupm.com/packages/com.virgis.mdal/
+
 
 Development Source
 ------------------------------------------------------------------------------


### PR DESCRIPTION
- Fixes a typo in the Download page
- adds a reference to the Unity Package Manager package for MDAL which is a subsidiary of the conda package