### PR TITLE
Add Status calls to C API

### DIFF
--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -112,6 +112,17 @@ MDAL_EXPORT const char *MDAL_Version();
 MDAL_EXPORT MDAL_Status MDAL_LastStatus();
 
 /**
+ * Resets the last status message
+ */
+MDAL_EXPORT void MDAL_ResetStatus();
+
+/*
+ * Sets the last status message
+ */
+
+MDAL_EXPORT void MDAL_SetStatus( MDAL_LogLevel Level, MDAL_Status status, const char* message);
+
+/**
  * Sets custom callback for logging output
  *
  * By default standard stdout is used as output.

--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -120,7 +120,7 @@ MDAL_EXPORT void MDAL_ResetStatus();
  * Sets the last status message
  */
 
-MDAL_EXPORT void MDAL_SetStatus( MDAL_LogLevel Level, MDAL_Status status, const char* message);
+MDAL_EXPORT void MDAL_SetStatus( MDAL_LogLevel Level, MDAL_Status status, const char *message );
 
 /**
  * Sets custom callback for logging output

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -31,24 +31,24 @@ MDAL_Status MDAL_LastStatus()
 
 MDAL_EXPORT void MDAL_ResetStatus()
 {
-    return MDAL::Log::resetLastStatus();
+  return MDAL::Log::resetLastStatus();
 }
 
-MDAL_EXPORT void MDAL_SetStatus( MDAL_LogLevel level, MDAL_Status status, const char* message )
+MDAL_EXPORT void MDAL_SetStatus( MDAL_LogLevel level, MDAL_Status status, const char *message )
 {
-    switch(level)
-    {
-        case MDAL_LogLevel::Error:
-            return MDAL::Log::error( status, message );
-        case MDAL_LogLevel::Warn:
-            return MDAL::Log::warning( status, message );
-        case MDAL_LogLevel::Info:
-            return MDAL::Log::info( message );
-        case MDAL_LogLevel::Debug:
-            return MDAL::Log::debug( message );
-        default:
-            return;
-    }
+  switch ( level )
+  {
+    case MDAL_LogLevel::Error:
+      return MDAL::Log::error( status, message );
+    case MDAL_LogLevel::Warn:
+      return MDAL::Log::warning( status, message );
+    case MDAL_LogLevel::Info:
+      return MDAL::Log::info( message );
+    case MDAL_LogLevel::Debug:
+      return MDAL::Log::debug( message );
+    default:
+      return;
+  }
 }
 
 void MDAL_SetLoggerCallback( MDAL_LoggerCallback callback )

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -29,6 +29,28 @@ MDAL_Status MDAL_LastStatus()
   return MDAL::Log::getLastStatus();
 }
 
+MDAL_EXPORT void MDAL_ResetStatus()
+{
+    return MDAL::Log::resetLastStatus();
+}
+
+MDAL_EXPORT void MDAL_SetStatus( MDAL_LogLevel level, MDAL_Status status, const char* message )
+{
+    switch(level)
+    {
+        case MDAL_LogLevel::Error:
+            return MDAL::Log::error( status, message );
+        case MDAL_LogLevel::Warn:
+            return MDAL::Log::warning( status, message );
+        case MDAL_LogLevel::Info:
+            return MDAL::Log::info( message );
+        case MDAL_LogLevel::Debug:
+            return MDAL::Log::debug( message );
+        default:
+            return;
+    }
+}
+
 void MDAL_SetLoggerCallback( MDAL_LoggerCallback callback )
 {
   MDAL::Log::setLoggerCallback( callback );

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -196,7 +196,7 @@ namespace MDAL
       Mesh *mParent = nullptr;
       bool mIsScalar = true;
       bool mIsPolar = false;
-      std::pair<double, double> mReferenceAngles = {-360, 0}; //default full rotation is negative to be consistent with usual geographical clockwise
+      std::pair<double, double> mReferenceAngles = { -360, 0}; //default full rotation is negative to be consistent with usual geographical clockwise
       MDAL_DataLocation mDataLocation = MDAL_DataLocation::DataOnVertices;
       std::string mUri; // file/uri from where it came
       Statistics mStatistics;

--- a/tests/test_api.cpp
+++ b/tests/test_api.cpp
@@ -285,7 +285,7 @@ TEST( ApiTest, LoggerApi )
   EXPECT_EQ( receivedLogMessage, "No driver with index: -1" );
   MDAL_ResetStatus();
   EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::None );
-  MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_NotEnoughMemory, "test" );
+  MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_NotEnoughMemory, "Test" );
   EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::Err_NotEnoughMemory );
   EXPECT_EQ( receivedLogLevel, MDAL_LogLevel::Error );
   EXPECT_EQ( receivedLogMessage, "Test" );

--- a/tests/test_api.cpp
+++ b/tests/test_api.cpp
@@ -281,12 +281,14 @@ TEST( ApiTest, LoggerApi )
 
   EXPECT_EQ( dr, nullptr );
   EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::Err_MissingDriver );
+  EXPECT_EQ( receivedLogLevel, MDAL_LogLevel::Error );
+  EXPECT_EQ( receivedLogMessage, "No driver with index: -1" );
   MDAL_ResetStatus();
   EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::None );
   MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_NotEnoughMemory, "test" );
   EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::Err_NotEnoughMemory );
   EXPECT_EQ( receivedLogLevel, MDAL_LogLevel::Error );
-  EXPECT_EQ( receivedLogMessage, "No driver with index: -1" );
+  EXPECT_EQ( receivedLogMessage, "Test" );
 }
 
 TEST( ApiTest, MeshNamesApi )

--- a/tests/test_api.cpp
+++ b/tests/test_api.cpp
@@ -281,6 +281,10 @@ TEST( ApiTest, LoggerApi )
 
   EXPECT_EQ( dr, nullptr );
   EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::Err_MissingDriver );
+  MDAL_ResetStatus();
+  EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::None );
+  MDAL_SetStatus( MDAL_LogLevel::Error, MDAL_Status::Err_NotEnoughMemory, "test" );
+  EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::Err_NotEnoughMemory );
   EXPECT_EQ( receivedLogLevel, MDAL_LogLevel::Error );
   EXPECT_EQ( receivedLogMessage, "No driver with index: -1" );
 }
@@ -367,18 +371,21 @@ TEST( ApiTest, MeshCreationApi )
                                     2.0, 0.0, 2.0,
                                     1.0, 2.0, 3.0,
                                     0.0, -2.0, 4.0,
-                                    2.0, -2.0, 4.0} );
+                                    2.0, -2.0, 4.0
+                                   } );
 
   std::vector<int> invalidVertexIndices( {0, 7, 3,
                                           1, 2, 3,
                                           4, 5, 2, 0,
-                                          0, 2, 1} );
+                                          0, 2, 1
+                                         } );
 
   std::vector<int> faceSizes( {3, 3, 4, 3} );
   std::vector<int> vertexIndices( {0, 1, 3,
                                    1, 2, 3,
                                    4, 5, 2, 0,
-                                   0, 2, 1} );
+                                   0, 2, 1
+                                  } );
 
   MDAL_MeshH mesh = nullptr;
   MDAL_M_addVertices( mesh, 6, coordinates.data() );

--- a/tests/test_hec2d.cpp
+++ b/tests/test_hec2d.cpp
@@ -31,10 +31,10 @@ TEST( MeshHec2dTest, simpleArea )
   std::vector<double> expectedCoords =
   {
     -5.5731e-06, 90.0, 0.00,
-      9.999988, 90.00000297, 0.00,
-      9.999988, 99.962230818, 0.00,
-      19.999988, 90.00000297, 0.00
-    };
+    9.999988, 90.00000297, 0.00,
+    9.999988, 99.962230818, 0.00,
+    19.999988, 90.00000297, 0.00
+  };
   EXPECT_EQ( expectedCoords.size(), 4 * 3 );
 
   std::vector<double> coordinates = getCoordinates( m, 4 );

--- a/tests/test_hec2d.cpp
+++ b/tests/test_hec2d.cpp
@@ -31,10 +31,10 @@ TEST( MeshHec2dTest, simpleArea )
   std::vector<double> expectedCoords =
   {
     -5.5731e-06, 90.0, 0.00,
-    9.999988, 90.00000297, 0.00,
-    9.999988, 99.962230818, 0.00,
-    19.999988, 90.00000297, 0.00
-  };
+      9.999988, 90.00000297, 0.00,
+      9.999988, 99.962230818, 0.00,
+      19.999988, 90.00000297, 0.00
+    };
   EXPECT_EQ( expectedCoords.size(), 4 * 3 );
 
   std::vector<double> coordinates = getCoordinates( m, 4 );


### PR DESCRIPTION
fixes #359 

Adds two calls to the C API 

- void MDAL_ResetStatus();
- void MDAL_SetStatus( MDAL_LogLevel Level, MDAL_Status status, const char *message );