### PR TITLE
Add Metadata to Mesh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ scripts/Debug
 Thumb.db
 cmake-build-debug/*
 Testing/*
+*.mdproj
+*.sln

--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -117,7 +117,7 @@ MDAL_EXPORT MDAL_Status MDAL_LastStatus();
  */
 MDAL_EXPORT void MDAL_ResetStatus();
 
-/*
+/**
  * Sets the last status message
  * \since MDAL 0.9.0
  */

--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -367,7 +367,7 @@ MDAL_EXPORT const char *MDAL_M_metadataKey( MDAL_MeshH mesh, int index );
 MDAL_EXPORT const char *MDAL_M_metadataValue( MDAL_MeshH mesh, int index );
 
 /**
- * Adds new metadata to the group
+ * Adds new metadata to the mesh
  *
  * \since MDAL 0.9.0
  */

--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -344,6 +344,36 @@ MDAL_EXPORT int MDAL_M_faceVerticesMaximumCount( MDAL_MeshH mesh );
 MDAL_EXPORT void MDAL_M_LoadDatasets( MDAL_MeshH mesh, const char *datasetFile );
 
 /**
+ * Returns number of metadata values
+ *
+ * \since MDAL 0.9.0
+ */
+MDAL_EXPORT int MDAL_M_metadataCount( MDAL_MeshH mesh );
+
+/**
+ * Returns dataset metadata key
+ * not thread-safe and valid only till next call
+ *
+ * \since MDAL 0.9.0
+ */
+MDAL_EXPORT const char *MDAL_M_metadataKey( MDAL_MeshH mesh, int index );
+
+/**
+ * Returns dataset metadata value
+ * not thread-safe and valid only till next call
+ *
+ * \since MDAL 0.9.0
+ */
+MDAL_EXPORT const char *MDAL_M_metadataValue( MDAL_MeshH mesh, int index );
+
+/**
+ * Adds new metadata to the group
+ *
+ * \since MDAL 0.9.0
+ */
+MDAL_EXPORT void MDAL_M_setMetadata( MDAL_MeshH mesh, const char *key, const char *val );
+
+/**
  * Returns dataset groups count
  */
 MDAL_EXPORT int MDAL_M_datasetGroupCount( MDAL_MeshH mesh );

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -361,6 +361,79 @@ void MDAL_M_LoadDatasets( MDAL_MeshH mesh, const char *datasetFile )
   MDAL::DriverManager::instance().loadDatasets( m, datasetFile );
 }
 
+int MDAL_M_metadataCount( MDAL_MeshH mesh )
+{
+  if ( !mesh )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, "Mesh is not valid (null)" );
+    return 0;
+  }
+  MDAL::Mesh *m = static_cast< MDAL::Mesh * >( mesh );
+  int len = static_cast<int>( m->metadata.size() );
+  return len;
+}
+
+const char *MDAL_M_metadataKey( MDAL_MeshH mesh, int index )
+{
+  if ( !mesh )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, "Mesh is not valid (null)" );
+    return EMPTY_STR;
+  }
+  MDAL::Mesh *m = static_cast< MDAL::Mesh * >( mesh );
+  int len = static_cast<int>( m->metadata.size() );
+  if ( len <= index )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, "Requested index: " + std::to_string( index ) + " is out of scope for metadata" );
+    return EMPTY_STR;
+  }
+  size_t i = static_cast<size_t>( index );
+  return _return_str( m->metadata[i].first );
+}
+
+const char *MDAL_M_metadataValue( MDAL_MeshH mesh, int index )
+{
+  if ( !mesh )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh,  "Mesh is not valid (null)" );
+    return EMPTY_STR;
+  }
+  MDAL::Mesh *m = static_cast< MDAL::Mesh * >( mesh );
+  int len = static_cast<int>( m->metadata.size() );
+  if ( len <= index )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, "Requested index: " + std::to_string( index ) + " is out of scope for metadata" );
+    return EMPTY_STR;
+  }
+  size_t i = static_cast<size_t>( index );
+  return _return_str( m->metadata[i].second );
+}
+
+void MDAL_M_setMetadata( MDAL_MeshH mesh, const char *key, const char *val )
+{
+  if ( !mesh )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh,  "Mesh is not valid (null)" );
+  }
+
+  if ( !key )
+  {
+    MDAL::Log::error( MDAL_Status::Err_InvalidData, "Passed pointer key is not valid (null)" );
+    return;
+  }
+
+  if ( !val )
+  {
+    MDAL::Log::error( MDAL_Status::Err_InvalidData, "Passed pointer val is not valid (null)" );
+    return;
+  }
+
+  const std::string k( key );
+  const std::string v( val );
+  MDAL::Mesh *m = static_cast< MDAL::Mesh * >( mesh );
+  m->setMetadata( k, v );
+}
+
 int MDAL_M_datasetGroupCount( MDAL_MeshH mesh )
 {
   if ( !mesh )

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -414,6 +414,7 @@ void MDAL_M_setMetadata( MDAL_MeshH mesh, const char *key, const char *val )
   if ( !mesh )
   {
     MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh,  "Mesh is not valid (null)" );
+    return;
   }
 
   if ( !key )

--- a/mdal/mdal_data_model.cpp
+++ b/mdal/mdal_data_model.cpp
@@ -192,9 +192,9 @@ void MDAL::DatasetGroup::setMetadata( const std::string &key, const std::string 
     metadata.push_back( std::make_pair( key, val ) );
 }
 
-void MDAL::DatasetGroup::setMetadata( const MDAL::Metadata &metadata )
+void MDAL::DatasetGroup::setMetadata( const MDAL::Metadata &new_metadata )
 {
-  for ( const auto &meta : metadata )
+  for ( const auto &meta : new_metadata )
     setMetadata( meta.first, meta.second );
 }
 
@@ -390,9 +390,9 @@ void MDAL::Mesh::setMetadata( const std::string &key, const std::string &val )
     metadata.push_back( std::make_pair( key, val ) );
 }
 
-void MDAL::Mesh::setMetadata( const MDAL::Metadata &metadata )
+void MDAL::Mesh::setMetadata( const MDAL::Metadata &new_metadata )
 {
-  for ( const auto &meta : metadata )
+  for ( const auto &meta : new_metadata )
     setMetadata( meta.first, meta.second );
 }
 

--- a/mdal/mdal_data_model.cpp
+++ b/mdal/mdal_data_model.cpp
@@ -363,6 +363,40 @@ void MDAL::Mesh::setSourceCrsFromPrjFile( const std::string &filename )
   setSourceCrs( proj );
 }
 
+std::string MDAL::Mesh::getMetadata( const std::string &key )
+{
+  for ( auto &pair : metadata )
+  {
+    if ( pair.first == key )
+    {
+      return pair.second;
+    }
+  }
+  return std::string();
+}
+
+void MDAL::Mesh::setMetadata( const std::string &key, const std::string &val )
+{
+  bool found = false;
+  for ( auto &pair : metadata )
+  {
+    if ( pair.first == key )
+    {
+      found = true;
+      pair.second = val;
+    }
+  }
+  if ( !found )
+    metadata.push_back( std::make_pair( key, val ) );
+}
+
+void MDAL::Mesh::setMetadata( const MDAL::Metadata &metadata )
+{
+  for ( const auto &meta : metadata )
+    setMetadata( meta.first, meta.second );
+}
+
+
 std::string MDAL::Mesh::uri() const
 {
   return mUri;

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -267,6 +267,12 @@ namespace MDAL
       std::string crs() const;
       size_t faceVerticesMaximumCount() const;
 
+      std::string getMetadata( const std::string &key );
+      void setMetadata( const std::string &key, const std::string &val );
+      void setMetadata( const Metadata &metadata );
+
+      Metadata metadata;
+
       virtual void closeSource() {};
 
       virtual bool isEditable() const {return false;}

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -152,7 +152,7 @@ namespace MDAL
 
       std::string getMetadata( const std::string &key );
       void setMetadata( const std::string &key, const std::string &val );
-      void setMetadata( const Metadata &metadata );
+      void setMetadata( const Metadata &new_metadata );
 
       std::string name();
       void setName( const std::string &name );
@@ -269,7 +269,7 @@ namespace MDAL
 
       std::string getMetadata( const std::string &key );
       void setMetadata( const std::string &key, const std::string &val );
-      void setMetadata( const Metadata &metadata );
+      void setMetadata( const Metadata &new_metadata );
 
       Metadata metadata;
 

--- a/tests/test_api.cpp
+++ b/tests/test_api.cpp
@@ -66,6 +66,8 @@ TEST( ApiTest, MeshApi )
   EXPECT_EQ( MDAL_M_metadataCount( nullptr ), 0 );
   EXPECT_EQ( MDAL_M_metadataKey( nullptr, 0 ), std::string( "" ) );
   EXPECT_EQ( MDAL_M_metadataValue( nullptr, 0 ), std::string( "" ) );
+  MDAL_M_setMetadata( nullptr, nullptr, nullptr );
+  EXPECT_EQ( MDAL_LastStatus(), Err_IncompatibleMesh );
 }
 
 void _populateFaces( MDAL_MeshH m, std::vector<int> &ret, size_t faceOffsetsBufferLen, size_t vertexIndicesBufferLen )
@@ -463,6 +465,16 @@ TEST( ApiTest, MeshCreationApi )
   EXPECT_EQ( MDAL_M_metadataCount( mesh ), 1 );
   EXPECT_EQ( std::strcmp( MDAL_M_metadataKey( mesh, 0 ), "test" ), 0 );
   EXPECT_EQ( std::strcmp( MDAL_M_metadataValue( mesh, 0 ), "value" ), 0 );
+  EXPECT_EQ( std::strcmp( MDAL_M_metadataKey( mesh, 1 ), "" ), 0 );
+  EXPECT_EQ( MDAL_LastStatus(), Err_IncompatibleMesh );
+  MDAL_ResetStatus();
+  MDAL_M_setMetadata( mesh, "test", "value2" );
+  EXPECT_EQ( MDAL_LastStatus(), None );
+  EXPECT_EQ( MDAL_M_metadataCount( mesh ), 1 );
+  EXPECT_EQ( std::strcmp( MDAL_M_metadataKey( mesh, 0 ), "test" ), 0 );
+  EXPECT_EQ( std::strcmp( MDAL_M_metadataValue( mesh, 0 ), "value2" ), 0 );
+  MDAL_M_setMetadata( mesh, nullptr, nullptr );
+  EXPECT_EQ( MDAL_LastStatus(), Err_InvalidData );
 
   MDAL_CloseMesh( mesh );
 

--- a/tests/test_api.cpp
+++ b/tests/test_api.cpp
@@ -63,6 +63,9 @@ TEST( ApiTest, MeshApi )
   EXPECT_EQ( MDAL_M_addDatasetGroup( nullptr, nullptr, MDAL_DataLocation::DataOnVertices, true, nullptr, nullptr ), nullptr );
   EXPECT_EQ( MDAL_M_addDatasetGroup( nullptr, nullptr, MDAL_DataLocation::DataOnVolumes, true, nullptr, nullptr ), nullptr );
   EXPECT_EQ( MDAL_M_driverName( nullptr ), nullptr );
+  EXPECT_EQ( MDAL_M_metadataCount( nullptr ), 0 );
+  EXPECT_EQ( MDAL_M_metadataKey( nullptr, 0 ), std::string( "" ) );
+  EXPECT_EQ( MDAL_M_metadataValue( nullptr, 0 ), std::string( "" ) );
 }
 
 void _populateFaces( MDAL_MeshH m, std::vector<int> &ret, size_t faceOffsetsBufferLen, size_t vertexIndicesBufferLen )
@@ -454,6 +457,12 @@ TEST( ApiTest, MeshCreationApi )
 
   MDAL_M_setProjection( mesh, "EPSG:32620" );
   EXPECT_EQ( MDAL_LastStatus(), None );
+
+  MDAL_M_setMetadata( mesh, "test", "value" );
+  EXPECT_EQ( MDAL_LastStatus(), None );
+  EXPECT_EQ( MDAL_M_metadataCount( mesh ), 1 );
+  EXPECT_EQ( std::strcmp( MDAL_M_metadataKey( mesh, 0 ), "test" ), 0 );
+  EXPECT_EQ( std::strcmp( MDAL_M_metadataValue( mesh, 0 ), "value" ), 0 );
 
   MDAL_CloseMesh( mesh );
 


### PR DESCRIPTION
Working on making the Python interface write enabled and making the PLY driver write-enabled, I have realised that there is a need for metadata on the mesh. The primary use case for this is to retain format related information (in the PLY case e.g. whether the file is text or binary) to allow round trip consistency.

My preferred way to do this is to add the same metadata capabilities to the mesh object as is currently found on the DatasetGroup object (rather than try to proliferate driver specific functionality).

I am proposing that we basically copy the metadata related methods and functionality from the DatasetGroup object to the Mesh object to provide consistency.

This is a NON BREAKING change to the API - since it does not change any current functionality and does not require that the driver uses the metadata in any way. It will, however, allow more flexibility for future drivers etc.