### PR TITLE
Add MemoryDataset3D

### DIFF
--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -625,7 +625,7 @@ MDAL_EXPORT MDAL_DatasetH MDAL_G_addDataset(
  * \param time time for dataset (hours)
  * \param values For scalar data, the size must be volume count
  *               For vector data , the size must be volume count * 2 (x1, y1, x2, y2, ..., xN, yN)
- * \param verticalLevelCount Int Array holding the numver of vertical levels for each face.
+ * \param verticalLevelCount Int Array holding the number of vertical levels for each face.
  *               Size must be the face count
  * \param verticalExtrusion Double Array holding the vertical level values for the voxels
  *               Size must be Face count + Volume count

--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -611,6 +611,36 @@ MDAL_EXPORT MDAL_DatasetH MDAL_G_addDataset(
 );
 
 /**
+ * Adds empty (new) 3D dataset to the group
+ * This increases dataset group count MDAL_G_datasetCount() by 1
+ *
+ * The dataset is opened in edit mode.
+ * To persist dataset, call MDAL_G_closeEditMode() on parent group
+ *
+ * Minimum and maximum dataset values are automatically calculated
+ *
+ * Only for 3D datasets
+ *
+ * \param group parent group handle
+ * \param time time for dataset (hours)
+ * \param values For scalar data, the size must be volume count
+ *               For vector data , the size must be volume count * 2 (x1, y1, x2, y2, ..., xN, yN)
+ * \param verticalLevelCount Int Array holding the numver of vertical levels for each face.
+ *               Size must be the face count
+ * \param verticalExtrusion Double Array holding the vertical level values for the voxels
+ *               Size must be Face count + Volume count
+ * \returns empty pointer if not possible to create dataset (e.g. group opened in read mode), otherwise handle to new dataset
+ */
+
+MDAL_EXPORT MDAL_DatasetH MDAL_G_addDataset3D(
+  MDAL_DatasetGroupH group,
+  double time,
+  const double *values,
+  const int *verticalLevelCount,
+  const double *verticalExtrusions
+);
+
+/**
  * Returns whether dataset group is in edit mode
  */
 MDAL_EXPORT bool MDAL_G_isInEditMode( MDAL_DatasetGroupH group );

--- a/mdal/frmts/mdal_driver.cpp
+++ b/mdal/frmts/mdal_driver.cpp
@@ -120,7 +120,7 @@ void MDAL::Driver::createDataset( MDAL::DatasetGroup *group, MDAL::RelativeTimes
 {
   size_t count = 0;
   size_t facesCount = group->mesh()->facesCount();
-  size_t maxVerticalLevel = 0;
+  int maxVerticalLevel = 0;
   for ( size_t i = 0; i < facesCount; i++ )
   {
     count += verticalLevelCounts[i];

--- a/mdal/frmts/mdal_driver.cpp
+++ b/mdal/frmts/mdal_driver.cpp
@@ -116,4 +116,27 @@ void MDAL::Driver::createDataset( MDAL::DatasetGroup *group, MDAL::RelativeTimes
   group->datasets.push_back( dataset );
 }
 
+void MDAL::Driver::createDataset( MDAL::DatasetGroup *group, MDAL::RelativeTimestamp time, const double *values, const int *verticalLevelCounts, const double *verticalExtrusions )
+{
+  size_t count = 0;
+  size_t facesCount = group->mesh()->facesCount();
+  size_t maxVerticalLevel = 0;
+  for ( size_t i = 0; i < facesCount; i++ )
+  {
+    count += verticalLevelCounts[i];
+    if ( verticalLevelCounts[i] > maxVerticalLevel ) maxVerticalLevel = verticalLevelCounts[i];
+  };
+
+  std::shared_ptr<MDAL::MemoryDataset3D> dataset = std::make_shared< MemoryDataset3D >( group, count, maxVerticalLevel, verticalLevelCounts, verticalExtrusions );
+  dataset->setTime( time );
+
+  if ( !group->isScalar() )
+    count *= 2;
+
+  memcpy( dataset->values(), values, sizeof( double ) * count );
+
+  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  group->datasets.push_back( dataset );
+}
+
 bool MDAL::Driver::persist( MDAL::DatasetGroup * ) { return true; } // failure

--- a/mdal/frmts/mdal_driver.hpp
+++ b/mdal/frmts/mdal_driver.hpp
@@ -68,11 +68,18 @@ namespace MDAL
         bool hasScalarData,
         const std::string &datasetGroupFile );
 
-      // create new dataset from array
+      // create new 2D dataset from array
       virtual void createDataset( DatasetGroup *group,
                                   RelativeTimestamp time,
                                   const double *values,
                                   const int *active );
+
+      // create new 3D dataset from array
+      virtual void createDataset( DatasetGroup *group,
+                                  RelativeTimestamp time,
+                                  const double *values,
+                                  const int *verticalLevelCount,
+                                  const double *verticalExtrusion );
 
       // persist to the file
       // returns true on error, false on success

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -884,12 +884,6 @@ MDAL_DatasetH MDAL_G_addDataset( MDAL_DatasetGroupH group, double time, const do
     return nullptr;
   }
 
-  if ( g->dataLocation() == MDAL_DataLocation::DataOnVolumes )
-  {
-    MDAL::Log::error( MDAL_Status::Err_MissingDriverCapability, "Dataset Group has data on 3D volumes" );
-    return nullptr;
-  }
-
   if ( active && g->dataLocation() != MDAL_DataLocation::DataOnVertices )
   {
     MDAL::Log::error( MDAL_Status::Err_IncompatibleDataset, "Active flag is only supported on datasets with data on vertices" );

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -938,12 +938,6 @@ MDAL_DatasetH MDAL_G_addDataset3D( MDAL_DatasetGroupH group, double time, const 
     return nullptr;
   }
 
-  if ( !dr->hasWriteDatasetCapability( g->dataLocation() ) )
-  {
-    MDAL::Log::error( MDAL_Status::Err_MissingDriverCapability, "Driver " + driverName + " does not have Write Dataset capability" );
-    return nullptr;
-  }
-
   if ( g->dataLocation() != MDAL_DataLocation::DataOnVolumes )
   {
     MDAL::Log::error( MDAL_Status::Err_MissingDriverCapability, "Cannot write 3D data to a Dataset Group that does not have Data On Volumes" );

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -884,15 +884,15 @@ MDAL_DatasetH MDAL_G_addDataset( MDAL_DatasetGroupH group, double time, const do
     return nullptr;
   }
 
-  if ( active && g->dataLocation() != MDAL_DataLocation::DataOnVertices )
-  {
-    MDAL::Log::error( MDAL_Status::Err_IncompatibleDataset, "Active flag is only supported on datasets with data on vertices" );
-    return nullptr;
-  }
-
   if ( g->dataLocation() == MDAL_DataLocation::DataOnVolumes )
   {
     MDAL::Log::error( MDAL_Status::Err_MissingDriverCapability, "Cannot save 3D dataset as a 2D dataset" );
+    return nullptr;
+  }
+
+  if ( active && g->dataLocation() != MDAL_DataLocation::DataOnVertices )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleDataset, "Active flag is only supported on datasets with data on vertices" );
     return nullptr;
   }
 
@@ -919,7 +919,7 @@ MDAL_DatasetH MDAL_G_addDataset3D( MDAL_DatasetGroupH group, double time, const 
 
   if ( !values || !verticalLevelCount || !verticalExtrusions )
   {
-    MDAL::Log::error( MDAL_Status::Err_InvalidData, "Passed pointer Values is not valid" );
+    MDAL::Log::error( MDAL_Status::Err_InvalidData, "Passed pointer Values are not valid" );
     return nullptr;
   }
 
@@ -946,7 +946,7 @@ MDAL_DatasetH MDAL_G_addDataset3D( MDAL_DatasetGroupH group, double time, const 
 
   if ( g->dataLocation() != MDAL_DataLocation::DataOnVolumes )
   {
-    MDAL::Log::error( MDAL_Status::Err_MissingDriverCapability, "Dataset Group does not have data on 3D volumes" );
+    MDAL::Log::error( MDAL_Status::Err_MissingDriverCapability, "Cannot write 3D data to a Dataset Group that does not have Data On Volumes" );
     return nullptr;
   }
 

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -890,6 +890,12 @@ MDAL_DatasetH MDAL_G_addDataset( MDAL_DatasetGroupH group, double time, const do
     return nullptr;
   }
 
+  if ( g->dataLocation() == MDAL_DataLocation::DataOnVolumes )
+  {
+    MDAL::Log::error( MDAL_Status::Err_MissingDriverCapability, "Cannot save 3D dataset as a 2D dataset" );
+    return nullptr;
+  }
+
   const size_t index = g->datasets.size();
   MDAL::RelativeTimestamp t( time, MDAL::RelativeTimestamp::hours );
   dr->createDataset( g,

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -903,6 +903,61 @@ MDAL_DatasetH MDAL_G_addDataset( MDAL_DatasetGroupH group, double time, const do
     return nullptr;
 }
 
+MDAL_DatasetH MDAL_G_addDataset3D( MDAL_DatasetGroupH group, double time, const double *values, const int *verticalLevelCount, const double *verticalExtrusions )
+{
+  if ( !group )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleDataset, "Dataset Group is not valid (null)" );
+    return nullptr;
+  }
+
+  if ( !values || !verticalLevelCount || !verticalExtrusions )
+  {
+    MDAL::Log::error( MDAL_Status::Err_InvalidData, "Passed pointer Values is not valid" );
+    return nullptr;
+  }
+
+  MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
+  if ( !g->isInEditMode() )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleDataset, "Dataset Group is not in edit mode" );
+    return nullptr;
+  }
+
+  const std::string driverName = g->driverName();
+  std::shared_ptr<MDAL::Driver> dr = MDAL::DriverManager::instance().driver( driverName );
+  if ( !dr )
+  {
+    MDAL::Log::error( MDAL_Status::Err_MissingDriver, "Driver name " + driverName + " saved in dataset group could not be found" );
+    return nullptr;
+  }
+
+  if ( !dr->hasWriteDatasetCapability( g->dataLocation() ) )
+  {
+    MDAL::Log::error( MDAL_Status::Err_MissingDriverCapability, "Driver " + driverName + " does not have Write Dataset capability" );
+    return nullptr;
+  }
+
+  if ( g->dataLocation() != MDAL_DataLocation::DataOnVolumes )
+  {
+    MDAL::Log::error( MDAL_Status::Err_MissingDriverCapability, "Dataset Group does not have data on 3D volumes" );
+    return nullptr;
+  }
+
+  const size_t index = g->datasets.size();
+  MDAL::RelativeTimestamp t( time, MDAL::RelativeTimestamp::hours );
+  dr->createDataset( g,
+                     t,
+                     values,
+                     verticalLevelCount,
+                     verticalExtrusions
+                   );
+  if ( index < g->datasets.size() ) // we have new dataset
+    return static_cast< MDAL_DatasetGroupH >( g->datasets[ index ].get() );
+  else
+    return nullptr;
+}
+
 bool MDAL_G_isInEditMode( MDAL_DatasetGroupH group )
 {
   if ( !group )

--- a/mdal/mdal_memory_data_model.cpp
+++ b/mdal/mdal_memory_data_model.cpp
@@ -159,7 +159,7 @@ size_t MDAL::MemoryDataset3D::verticalLevelCountData( size_t indexStart, size_t 
     return 0;
 
   size_t copyValues = std::min( nValues - indexStart, count );
-  memcpy( buffer, mVerticalLevelCounts.data() + indexStart, copyValues * sizeof( double ) );
+  memcpy( buffer, mVerticalLevelCounts.data() + indexStart, copyValues * sizeof( int ) );
   return copyValues;
 }
 
@@ -185,7 +185,7 @@ size_t MDAL::MemoryDataset3D::faceToVolumeData( size_t indexStart, size_t count,
     return 0;
 
   size_t copyValues = std::min( nValues - indexStart, count );
-  memcpy( buffer, mFaceToVolume.data() + indexStart, copyValues * sizeof( double ) );
+  memcpy( buffer, mFaceToVolume.data() + indexStart, copyValues * sizeof( int ) );
   return copyValues;
 }
 

--- a/mdal/mdal_memory_data_model.cpp
+++ b/mdal/mdal_memory_data_model.cpp
@@ -118,17 +118,17 @@ size_t MDAL::MemoryDataset2D::vectorData( size_t indexStart, size_t count, doubl
 }
 
 MDAL::MemoryDataset3D::MemoryDataset3D(
-        DatasetGroup *grp,
-        size_t volumes,
-        size_t maxVerticalLevelCount,
-        const int *verticalLevelCounts,
-        const double *verticalExtrusions
-      ) : Dataset3D(grp, volumes, maxVerticalLevelCount),
-          mValues( group()->isScalar() ? volumes : 2 * volumes,
-             std::numeric_limits<double>::quiet_NaN() ),
-          mFaceToVolume( grp->mesh()->facesCount(), 0 ),
-          mVerticalLevelCounts( verticalLevelCounts, verticalLevelCounts + grp->mesh()->facesCount() ),
-          mVerticalExtrusions( verticalExtrusions, verticalExtrusions + grp->mesh()->facesCount() + volumes )
+  DatasetGroup *grp,
+  size_t volumes,
+  size_t maxVerticalLevelCount,
+  const int *verticalLevelCounts,
+  const double *verticalExtrusions
+) : Dataset3D( grp, volumes, maxVerticalLevelCount ),
+  mValues( group()->isScalar() ? volumes : 2 * volumes,
+           std::numeric_limits<double>::quiet_NaN() ),
+  mFaceToVolume( grp->mesh()->facesCount(), 0 ),
+  mVerticalLevelCounts( verticalLevelCounts, verticalLevelCounts + grp->mesh()->facesCount() ),
+  mVerticalExtrusions( verticalExtrusions, verticalExtrusions + grp->mesh()->facesCount() + volumes )
 {
   updateIndices();
 }
@@ -138,7 +138,7 @@ MDAL::MemoryDataset3D::~MemoryDataset3D() = default;
 void MDAL::MemoryDataset3D::updateIndices()
 {
   size_t offset = 0;
-  for (size_t i = 0; i < mVerticalLevelCounts.size(); i++ )
+  for ( size_t i = 0; i < mVerticalLevelCounts.size(); i++ )
   {
     mFaceToVolume[i] = offset;
     offset += mVerticalLevelCounts[i];

--- a/mdal/mdal_memory_data_model.cpp
+++ b/mdal/mdal_memory_data_model.cpp
@@ -117,6 +117,106 @@ size_t MDAL::MemoryDataset2D::vectorData( size_t indexStart, size_t count, doubl
   return copyValues;
 }
 
+MDAL::MemoryDataset3D::MemoryDataset3D(
+        DatasetGroup *grp,
+        size_t volumes,
+        size_t maxVerticalLevelCount,
+        const int *verticalLevelCounts,
+        const double *verticalExtrusions
+      ) : Dataset3D(grp, volumes, maxVerticalLevelCount),
+          mValues( group()->isScalar() ? volumes : 2 * volumes,
+             std::numeric_limits<double>::quiet_NaN() ),
+          mFaceToVolume( grp->mesh()->facesCount(), 0 ),
+          mVerticalLevelCounts( verticalLevelCounts, verticalLevelCounts + grp->mesh()->facesCount() ),
+          mVerticalExtrusions( verticalExtrusions, verticalExtrusions + grp->mesh()->facesCount() + volumes )
+{
+  updateIndices();
+}
+
+MDAL::MemoryDataset3D::~MemoryDataset3D() = default;
+
+void MDAL::MemoryDataset3D::updateIndices()
+{
+  size_t offset = 0;
+  for (size_t i = 0; i < mVerticalLevelCounts.size(); i++ )
+  {
+    mFaceToVolume[i] = offset;
+    offset += mVerticalLevelCounts[i];
+    if ( offset > volumesCount() )
+    {
+      MDAL::Log::error( Err_InvalidData, "Incompatible volume count" );
+      return;
+    }
+  }
+}
+
+size_t MDAL::MemoryDataset3D::verticalLevelCountData( size_t indexStart, size_t count, int *buffer )
+{
+  size_t nValues = group()->mesh()->facesCount();
+  assert( mVerticalLevelCounts.size() == nValues );
+
+  if ( ( count < 1 ) || ( indexStart >= nValues ) )
+    return 0;
+
+  size_t copyValues = std::min( nValues - indexStart, count );
+  memcpy( buffer, mVerticalLevelCounts.data() + indexStart, copyValues * sizeof( double ) );
+  return copyValues;
+}
+
+size_t MDAL::MemoryDataset3D::verticalLevelData( size_t indexStart, size_t count, double *buffer )
+{
+  size_t nValues = group()->mesh()->facesCount() + valuesCount();
+  assert( mVerticalExtrusions.size() == nValues );
+
+  if ( ( count < 1 ) || ( indexStart >= nValues ) )
+    return 0;
+
+  size_t copyValues = std::min( nValues - indexStart, count );
+  memcpy( buffer, mVerticalExtrusions.data() + indexStart, copyValues * sizeof( double ) );
+  return copyValues;
+}
+
+size_t MDAL::MemoryDataset3D::faceToVolumeData( size_t indexStart, size_t count, int *buffer )
+{
+  size_t nValues = group()->mesh()->facesCount();
+  assert( mFaceToVolume.size() == nValues );
+
+  if ( ( count < 1 ) || ( indexStart >= nValues ) )
+    return 0;
+
+  size_t copyValues = std::min( nValues - indexStart, count );
+  memcpy( buffer, mFaceToVolume.data() + indexStart, copyValues * sizeof( double ) );
+  return copyValues;
+}
+
+size_t MDAL::MemoryDataset3D::scalarVolumesData( size_t indexStart, size_t count, double *buffer )
+{
+  assert( group()->isScalar() ); //checked in C API interface
+  size_t nValues = valuesCount();
+  assert( mValues.size() == nValues );
+
+  if ( ( count < 1 ) || ( indexStart >= nValues ) )
+    return 0;
+
+  size_t copyValues = std::min( nValues - indexStart, count );
+  memcpy( buffer, mValues.data() + indexStart, copyValues * sizeof( double ) );
+  return copyValues;
+}
+
+size_t MDAL::MemoryDataset3D::vectorVolumesData( size_t indexStart, size_t count, double *buffer )
+{
+  assert( !group()->isScalar() ); //checked in C API interface
+  size_t nValues = valuesCount();
+  assert( mValues.size() == nValues * 2 );
+
+  if ( ( count < 1 ) || ( indexStart >= nValues ) )
+    return 0;
+
+  size_t copyValues = std::min( nValues - indexStart, count );
+  memcpy( buffer, mValues.data() + 2 * indexStart, 2 * copyValues * sizeof( double ) );
+  return copyValues;
+}
+
 MDAL::MemoryMesh::MemoryMesh( const std::string &driverName,
                               size_t faceVerticesMaximumCount,
                               const std::string &uri )

--- a/mdal/mdal_memory_data_model.hpp
+++ b/mdal/mdal_memory_data_model.hpp
@@ -168,6 +168,121 @@ namespace MDAL
       std::vector<int> mActive;
   };
 
+class MemoryDataset3D: public Dataset3D
+  {
+    public:
+
+      MemoryDataset3D(
+        DatasetGroup *grp,
+        size_t volumes,
+        size_t maxVerticalLevelCount,
+        const int *verticalLevelCounts,
+        const double *verticalExtrusions
+      );
+
+      ~MemoryDataset3D() override;
+
+
+      void setScalarValue( size_t index, double value )
+      {
+        assert( mValues.size() > index );
+        assert( group()->isScalar() );
+        mValues[index] = value;
+      }
+
+      void setVectorValue( size_t index, double x, double y )
+      {
+        assert( mValues.size() > 2 * index + 1 );
+        assert( !group()->isScalar() );
+        mValues[2 * index] = x;
+        mValues[2 * index + 1] = y;
+      }
+
+      void setValueX( size_t index, double x )
+      {
+        assert( mValues.size() > 2 * index );
+        assert( !group()->isScalar() );
+
+        mValues[2 * index] = x;
+      }
+
+      void setValueY( size_t index, double x )
+      {
+        assert( mValues.size() > 2 * index + 1 );
+        assert( !group()->isScalar() );
+        mValues[2 * index + 1] = x;
+      }
+
+      double valueX( size_t index ) const
+      {
+        assert( mValues.size() > 2 * index + 1 );
+        assert( !group()->isScalar() );
+        return mValues[2 * index];
+      }
+
+      double valueY( size_t index ) const
+      {
+        assert( mValues.size() > 2 * index + 1 );
+        assert( !group()->isScalar() );
+        return mValues[2 * index + 1];
+      }
+
+      double scalarValue( size_t index ) const
+      {
+        assert( mValues.size() > index );
+        assert( group()->isScalar() );
+        return mValues[index];
+      }
+
+      void updateIndices();
+
+      //! Returns pointer to internal buffer with values
+      //! Never null, already allocated
+      //! for vector datasets in form x1, y1, ..., xN, yN
+      double *values()
+      {
+        return mValues.data();
+      }
+
+      size_t verticalLevelCountData( size_t indexStart, size_t count, int *buffer ) override;
+      size_t verticalLevelData( size_t indexStart, size_t count, double *buffer ) override;
+      size_t faceToVolumeData( size_t indexStart, size_t count, int *buffer ) override;
+      size_t scalarVolumesData( size_t indexStart, size_t count, double *buffer ) override;
+      size_t vectorVolumesData( size_t indexStart, size_t count, double *buffer ) override;
+
+    private:
+      /**
+       * Stores vector2d/scalar data for dataset in form
+       * scalars: x1, x2, x3, ..., xN
+       * vector2D: x1, y1, x2, y2, x3, y3, .... , xN, yN
+       *
+       * all values are initialized to std::numerical_limits<double>::quiet_NaN ( == NODATA )
+       *
+       */
+      std::vector<double> mValues;
+
+      /**
+       * Store The first index of 3D volume for particular mesh’s face in 3D Stacked Meshes
+       *
+       * All values are initialised to actual values
+       */
+      std::vector<int> mFaceToVolume;
+
+      /**
+       * Store Number of vertical level for particular mesh’s face in 3D Stacked Meshes.
+       *
+       * All values are initialised to actual values
+       */
+      std::vector<int> mVerticalLevelCounts;
+
+      /**
+       * Store Vertical level extrusion for particular mesh’s face in 3D Stacked Meshes.
+       *
+       * All values are initialised to actual values
+       */
+      std::vector<double> mVerticalExtrusions;
+  };
+
   class MemoryMesh: public Mesh
   {
     public:

--- a/mdal/mdal_memory_data_model.hpp
+++ b/mdal/mdal_memory_data_model.hpp
@@ -168,7 +168,7 @@ namespace MDAL
       std::vector<int> mActive;
   };
 
-class MemoryDataset3D: public Dataset3D
+  class MemoryDataset3D: public Dataset3D
   {
     public:
 

--- a/tests/test_ply.cpp
+++ b/tests/test_ply.cpp
@@ -10,7 +10,6 @@
 #include "mdal_utils.hpp"
 #include "../mdal/frmts/mdal_driver.hpp"
 #include "../mdal/mdal_data_model.hpp"
-#include "../mdal/mdal_datetime.hpp"
 
 
 TEST( MeshPlyTest, WrongFiles )
@@ -413,7 +412,6 @@ TEST( Memory3D, ScalarMesh )
 
 // create a new 3D dataset
   index = g2->datasets.size();
-  MDAL::RelativeTimestamp t( 0, MDAL::RelativeTimestamp::hours );
   size_t f_count = m->facesCount();
   std::shared_ptr<MDAL::Dataset> dataset = g->datasets[0];
   size_t v_count = dataset->volumesCount();
@@ -424,7 +422,7 @@ TEST( Memory3D, ScalarMesh )
   dataset->verticalLevelData( 0, f_count + v_count, ve.data() );
   dataset->scalarVolumesData( 0, v_count, values.data() );
   dr->createDataset( g2.get(),
-                     t,
+                     dataset->timestamp(),
                      values.data(),
                      lc.data(),
                      ve.data()
@@ -474,7 +472,6 @@ TEST( Memory3D, VectorMesh )
 
 // create a new 3D dataset
   index = g2->datasets.size();
-  MDAL::RelativeTimestamp t( 0, MDAL::RelativeTimestamp::hours );
   size_t f_count = m->facesCount();
   std::shared_ptr<MDAL::Dataset> dataset = g->datasets[0];
   size_t v_count = dataset->volumesCount();
@@ -485,7 +482,7 @@ TEST( Memory3D, VectorMesh )
   dataset->verticalLevelData( 0, f_count + v_count, ve.data() );
   dataset->vectorVolumesData( 0, v_count, values.data() );
   dr->createDataset( g2.get(),
-                     t,
+                     dataset->timestamp(),
                      values.data(),
                      lc.data(),
                      ve.data()

--- a/tests/test_ply.cpp
+++ b/tests/test_ply.cpp
@@ -382,8 +382,6 @@ TEST( MeshPlyFileTest, real_file )
   MDAL_CloseMesh( m );
 }
 
-#ifndef _WIN32
-
 // test the memorydataset3D
 TEST( Memory3D, ScalarMesh )
 {
@@ -398,10 +396,9 @@ TEST( Memory3D, ScalarMesh )
 
   MDAL::Mesh *m = static_cast< MDAL::Mesh * >( mesh );
   MDAL::Driver *dr = static_cast< MDAL::Driver * >( MDAL_driverFromName( "PLY" ) );
-  MDAL::DatasetGroup *g = static_cast<MDAL::DatasetGroup *>( group );
 
   // create a new 3D datasetGroup
-  size_t index = m->datasetGroups.size();
+  int index = m->datasetGroups.size();
   dr->createDatasetGroup( m,
                           "test",
                           MDAL_DataLocation::DataOnVolumes,
@@ -409,44 +406,33 @@ TEST( Memory3D, ScalarMesh )
                           "test.ply"
                         );
   ASSERT_TRUE( index < m->datasetGroups.size() );
-  std::shared_ptr<MDAL::DatasetGroup> g2 = m->datasetGroups[ index ];
-  MDAL_DatasetGroupH group2 = static_cast<MDAL_DatasetGroupH>( g2.get() );
+  MDAL_DatasetGroupH group2 = MDAL_M_datasetGroup( m, index );
   ASSERT_EQ( MDAL_G_dataLocation( group2 ), MDAL_DataLocation::DataOnVolumes );
 
 // create a new 3D dataset
-  index = g2->datasets.size();
-  size_t f_count = m->facesCount();
-  std::shared_ptr<MDAL::Dataset> dataset = g->datasets[0];
-  MDAL_DatasetH d = static_cast<MDAL_DatasetH>( dataset.get() );
-  size_t v_count = MDAL_D_valueCount( d );
+  int f_count = MDAL_M_faceCount( mesh );
+  MDAL_DatasetH dataset = MDAL_G_dataset( group, 0 );
+  int v_count = MDAL_D_valueCount( dataset );
   std::vector<int> lc( f_count, 0 );
   std::vector<int> f2V( f_count, 0 );
   std::vector<double> ve( f_count + v_count, 0 );
   std::vector<double> values( v_count, 0 );
-  dataset->verticalLevelCountData( 0, f_count, lc.data() );
-  dataset->faceToVolumeData( 0, f_count, f2V.data() );
-  dataset->verticalLevelData( 0, f_count + v_count, ve.data() );
-  dataset->scalarVolumesData( 0, v_count, values.data() );
-  dr->createDataset( g2.get(),
-                     dataset->timestamp(),
-                     values.data(),
-                     lc.data(),
-                     ve.data()
-                   );
-  ASSERT_TRUE( index < g2->datasets.size() );
-  std::shared_ptr<MDAL::Dataset> dataset2 = g2->datasets[ index ];
-  MDAL_DatasetH d2 = static_cast<MDAL_DatasetH>( dataset2.get() );
-  ASSERT_EQ( MDAL_D_valueCount( d2 ), v_count );
+  MDAL_D_data( dataset, 0, f_count, MDAL_DataType::VERTICAL_LEVEL_COUNT_INTEGER, lc.data() );
+  MDAL_D_data( dataset, 0, f_count, MDAL_DataType::FACE_INDEX_TO_VOLUME_INDEX_INTEGER, f2V.data() );
+  MDAL_D_data( dataset, 0, f_count + v_count, MDAL_DataType::VERTICAL_LEVEL_DOUBLE, ve.data() );
+  MDAL_D_data( dataset, 0, v_count, MDAL_DataType::SCALAR_VOLUMES_DOUBLE, values.data() );
+  MDAL_DatasetH dataset2 = MDAL_G_addDataset3D( group2, 0, values.data(), lc.data(), ve.data() );
+  ASSERT_EQ( MDAL_D_valueCount( dataset2 ), v_count );
 
   // test data equality
   std::vector<int> lc2( f_count, 0 );
   std::vector<int> f2V2( f_count, 0 );
   std::vector<double> ve2( f_count + v_count, 0 );
   std::vector<double> values2( v_count, 0 );
-  dataset2->verticalLevelCountData( 0, f_count, lc2.data() );
-  dataset2->faceToVolumeData( 0, f_count, f2V2.data() );
-  dataset2->verticalLevelData( 0, f_count + v_count, ve2.data() );
-  dataset2->scalarVolumesData( 0, v_count, values2.data() );
+  MDAL_D_data( dataset2, 0, f_count, MDAL_DataType::VERTICAL_LEVEL_COUNT_INTEGER, lc2.data() );
+  MDAL_D_data( dataset2, 0, f_count, MDAL_DataType::FACE_INDEX_TO_VOLUME_INDEX_INTEGER, f2V2.data() );
+  MDAL_D_data( dataset2, 0, f_count + v_count, MDAL_DataType::VERTICAL_LEVEL_DOUBLE, ve2.data() );
+  MDAL_D_data( dataset2, 0, v_count, MDAL_DataType::SCALAR_VOLUMES_DOUBLE, values2.data() );
   ASSERT_TRUE( compareVectors( lc, lc2 ) );
   ASSERT_TRUE( compareVectors( f2V, f2V2 ) );
   ASSERT_TRUE( compareVectors( ve, ve2 ) );
@@ -466,10 +452,9 @@ TEST( Memory3D, VectorMesh )
 
   MDAL::Mesh *m = static_cast< MDAL::Mesh * >( mesh );
   MDAL::Driver *dr = static_cast< MDAL::Driver * >( MDAL_driverFromName( "PLY" ) );
-  MDAL::DatasetGroup *g = static_cast<MDAL::DatasetGroup *>( group );
 
   // create a new 3D datasetGroup
-  size_t index = m->datasetGroups.size();
+  int index = m->datasetGroups.size();
   dr->createDatasetGroup( m,
                           "test",
                           MDAL_DataLocation::DataOnVolumes,
@@ -477,46 +462,33 @@ TEST( Memory3D, VectorMesh )
                           "test.ply"
                         );
   ASSERT_TRUE( index < m->datasetGroups.size() );
-  std::shared_ptr<MDAL::DatasetGroup> g2 = m->datasetGroups[ index ];
-  MDAL_DatasetGroupH group2 = static_cast<MDAL_DatasetGroupH>( g2.get() );
+  MDAL_DatasetGroupH group2 = MDAL_M_datasetGroup( m, index );
   ASSERT_EQ( MDAL_G_dataLocation( group2 ), MDAL_DataLocation::DataOnVolumes );
 
 // create a new 3D dataset
-  index = g2->datasets.size();
-  size_t f_count = m->facesCount();
-  std::shared_ptr<MDAL::Dataset> dataset = g->datasets[0];
-  MDAL_DatasetH d = static_cast<MDAL_DatasetH>( dataset.get() );
-  size_t v_count = MDAL_D_valueCount( d );
+  int f_count = MDAL_M_faceCount( mesh );
+  MDAL_DatasetH dataset = MDAL_G_dataset( group, 0 );
+  int v_count = MDAL_D_valueCount( dataset );
   std::vector<int> lc( f_count, 0 );
   std::vector<double> ve( f_count + v_count, 0 );
   std::vector<double> values( 2 * v_count, 0 );
-  dataset->verticalLevelCountData( 0, f_count, lc.data() );
-  dataset->verticalLevelData( 0, f_count + v_count, ve.data() );
-  dataset->vectorVolumesData( 0, v_count, values.data() );
-  dr->createDataset( g2.get(),
-                     dataset->timestamp(),
-                     values.data(),
-                     lc.data(),
-                     ve.data()
-                   );
-  ASSERT_TRUE( index < g2->datasets.size() );
-  std::shared_ptr<MDAL::Dataset> dataset2 = g2->datasets[ index ];
-  MDAL_DatasetH d2 = static_cast<MDAL_DatasetH>( dataset2.get() );
-  ASSERT_EQ( MDAL_D_valueCount( d2 ), v_count );
+  MDAL_D_data( dataset, 0, f_count, MDAL_DataType::VERTICAL_LEVEL_COUNT_INTEGER, lc.data() );
+  MDAL_D_data( dataset, 0, f_count + v_count, MDAL_DataType::VERTICAL_LEVEL_DOUBLE, ve.data() );
+  MDAL_D_data( dataset, 0, v_count, MDAL_DataType::VECTOR_2D_VOLUMES_DOUBLE, values.data() );
+  MDAL_DatasetH dataset2 = MDAL_G_addDataset3D( group2, 0, values.data(), lc.data(), ve.data() );
+  ASSERT_EQ( MDAL_D_valueCount( dataset2 ), v_count );
 
   // test data equality
   std::vector<int> lc2( f_count, 0 );
   std::vector<double> ve2( f_count + v_count, 0 );
   std::vector<double> values2( 2 * v_count, 0 );
-  dataset2->verticalLevelCountData( 0, f_count, lc2.data() );
-  dataset2->verticalLevelData( 0, f_count + v_count, ve2.data() );
-  dataset2->vectorVolumesData( 0, v_count, values2.data() );
+  MDAL_D_data( dataset2, 0, f_count, MDAL_DataType::VERTICAL_LEVEL_COUNT_INTEGER, lc2.data() );
+  MDAL_D_data( dataset2, 0, f_count + v_count, MDAL_DataType::VERTICAL_LEVEL_DOUBLE, ve2.data() );
+  MDAL_D_data( dataset2, 0, v_count, MDAL_DataType::VECTOR_2D_VOLUMES_DOUBLE, values2.data() );
   ASSERT_TRUE( compareVectors( lc, lc2 ) );
   ASSERT_TRUE( compareVectors( ve, ve2 ) );
   ASSERT_TRUE( compareVectors( values, values2 ) );
 }
-
-#endif
 
 int main( int argc, char **argv )
 {

--- a/tests/test_ply.cpp
+++ b/tests/test_ply.cpp
@@ -410,13 +410,15 @@ TEST( Memory3D, ScalarMesh )
                         );
   ASSERT_TRUE( index < m->datasetGroups.size() );
   std::shared_ptr<MDAL::DatasetGroup> g2 = m->datasetGroups[ index ];
-  ASSERT_TRUE( g->dataLocation() == g2->dataLocation() );
+  MDAL_DatasetGroupH group2 = static_cast<MDAL_DatasetGroupH>( g2.get() );
+  ASSERT_EQ( MDAL_G_dataLocation( group2 ), MDAL_DataLocation::DataOnVolumes );
 
 // create a new 3D dataset
   index = g2->datasets.size();
   size_t f_count = m->facesCount();
   std::shared_ptr<MDAL::Dataset> dataset = g->datasets[0];
-  size_t v_count = dataset->volumesCount();
+  MDAL_DatasetH d = static_cast<MDAL_DatasetH>( dataset.get() );
+  size_t v_count = MDAL_D_valueCount( d );
   std::vector<int> lc( f_count, 0 );
   std::vector<int> f2V( f_count, 0 );
   std::vector<double> ve( f_count + v_count, 0 );
@@ -433,7 +435,8 @@ TEST( Memory3D, ScalarMesh )
                    );
   ASSERT_TRUE( index < g2->datasets.size() );
   std::shared_ptr<MDAL::Dataset> dataset2 = g2->datasets[ index ];
-  ASSERT_TRUE( dataset2->valuesCount() == v_count );
+  MDAL_DatasetH d2 = static_cast<MDAL_DatasetH>( dataset2.get() );
+  ASSERT_EQ( MDAL_D_valueCount( d2 ), v_count );
 
   // test data equality
   std::vector<int> lc2( f_count, 0 );
@@ -475,13 +478,15 @@ TEST( Memory3D, VectorMesh )
                         );
   ASSERT_TRUE( index < m->datasetGroups.size() );
   std::shared_ptr<MDAL::DatasetGroup> g2 = m->datasetGroups[ index ];
-  ASSERT_TRUE( g->dataLocation() == g2->dataLocation() );
+  MDAL_DatasetGroupH group2 = static_cast<MDAL_DatasetGroupH>( g2.get() );
+  ASSERT_EQ( MDAL_G_dataLocation( group2 ), MDAL_DataLocation::DataOnVolumes );
 
 // create a new 3D dataset
   index = g2->datasets.size();
   size_t f_count = m->facesCount();
   std::shared_ptr<MDAL::Dataset> dataset = g->datasets[0];
-  size_t v_count = dataset->volumesCount();
+  MDAL_DatasetH d = static_cast<MDAL_DatasetH>( dataset.get() );
+  size_t v_count = MDAL_D_valueCount( d );
   std::vector<int> lc( f_count, 0 );
   std::vector<double> ve( f_count + v_count, 0 );
   std::vector<double> values( 2 * v_count, 0 );
@@ -496,7 +501,8 @@ TEST( Memory3D, VectorMesh )
                    );
   ASSERT_TRUE( index < g2->datasets.size() );
   std::shared_ptr<MDAL::Dataset> dataset2 = g2->datasets[ index ];
-  ASSERT_TRUE( dataset2->valuesCount() == v_count );
+  MDAL_DatasetH d2 = static_cast<MDAL_DatasetH>( dataset2.get() );
+  ASSERT_EQ( MDAL_D_valueCount( d2 ), v_count );
 
   // test data equality
   std::vector<int> lc2( f_count, 0 );

--- a/tests/test_ply.cpp
+++ b/tests/test_ply.cpp
@@ -418,9 +418,11 @@ TEST( Memory3D, ScalarMesh )
   std::shared_ptr<MDAL::Dataset> dataset = g->datasets[0];
   size_t v_count = dataset->volumesCount();
   std::vector<int> lc( f_count, 0 );
+  std::vector<int> f2V( f_count, 0 );
   std::vector<double> ve( f_count + v_count, 0 );
   std::vector<double> values( v_count, 0 );
   dataset->verticalLevelCountData( 0, f_count, lc.data() );
+  dataset->faceToVolumeData( 0, f_count, f2V.data() );
   dataset->verticalLevelData( 0, f_count + v_count, ve.data() );
   dataset->scalarVolumesData( 0, v_count, values.data() );
   dr->createDataset( g2.get(),
@@ -435,12 +437,15 @@ TEST( Memory3D, ScalarMesh )
 
   // test data equality
   std::vector<int> lc2( f_count, 0 );
+  std::vector<int> f2V2( f_count, 0 );
   std::vector<double> ve2( f_count + v_count, 0 );
   std::vector<double> values2( v_count, 0 );
   dataset2->verticalLevelCountData( 0, f_count, lc2.data() );
+  dataset2->faceToVolumeData( 0, f_count, f2V2.data() );
   dataset2->verticalLevelData( 0, f_count + v_count, ve2.data() );
   dataset2->scalarVolumesData( 0, v_count, values2.data() );
   ASSERT_TRUE( compareVectors( lc, lc2 ) );
+  ASSERT_TRUE( compareVectors( f2V, f2V2 ) );
   ASSERT_TRUE( compareVectors( ve, ve2 ) );
   ASSERT_TRUE( compareVectors( values, values2 ) );
 }

--- a/tests/test_ply.cpp
+++ b/tests/test_ply.cpp
@@ -10,6 +10,7 @@
 #include "mdal_utils.hpp"
 #include "../mdal/frmts/mdal_driver.hpp"
 #include "../mdal/mdal_data_model.hpp"
+#include "../mdal/mdal_datetime.hpp"
 
 
 TEST( MeshPlyTest, WrongFiles )

--- a/tests/test_ply.cpp
+++ b/tests/test_ply.cpp
@@ -382,6 +382,8 @@ TEST( MeshPlyFileTest, real_file )
   MDAL_CloseMesh( m );
 }
 
+#ifndef _WIN32
+
 // test the memorydataset3D
 TEST( Memory3D, ScalarMesh )
 {
@@ -503,6 +505,8 @@ TEST( Memory3D, VectorMesh )
   ASSERT_TRUE( compareVectors( values, values2 ) );
 }
 
+#endif
+
 int main( int argc, char **argv )
 {
   testing::InitGoogleTest( &argc, argv );
@@ -511,4 +515,3 @@ int main( int argc, char **argv )
   finalize_test();
   return ret;
 }
-


### PR DESCRIPTION
This PR addresses the issue of creating Volumetric datasets as discussed to some extent in [this conversation](https://lists.osgeo.org/pipermail/mdal-developer/2021-June/000034.html).

Currently - it is not possible to create 3D datasets through the C API because there is a hard-coded check to prevent it. This appears to be because there is no generic `MemoryDataset3D` to allow creating or writing these datasets.

Therefore - this PR :

- Adds `MemoryDataset3D`,
- Adds a new overload of `Driver::createDataset` to allow the creation of 3d datasets, and
- Adds a new call in the C API `MDAL_G_createDataset3D`

Together - this PR is essential to allow the writing of 3D datasets.

NOTE - since there are no drivers (yet) that can write 3D groups, this functionality cannot (yet) be tested through the C API (since it tests the capabilities). Interim tests have been added to the PLY driver tests using the C++ API, which will be updated when the write capable PLY driver is finalized. NOTE also that the interim tests (only - not the functionality) refuse to compile on Windows and I do not have the time to work the problem in what I hope is only a temporary test. The functionality of the PR does compile on Windows and has been tested. I just cannot get it to work in CI.