### PR TITLE
add API method for max vertices per face supported by driver

### DIFF
--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -217,6 +217,8 @@ MDAL_EXPORT const char *MDAL_DR_filters( MDAL_DriverH driver );
 
 /**
  * Returns the maximum number of vertices per face supported by the driver
+ *
+ * \since MDAL 0.9.0
  */
 MDAL_EXPORT int MDAL_DR_faceVerticesMaximumCount( MDAL_DriverH driver );
 
@@ -336,7 +338,7 @@ MDAL_EXPORT int MDAL_M_edgeCount( MDAL_MeshH mesh );
 MDAL_EXPORT int MDAL_M_faceCount( MDAL_MeshH mesh );
 
 /**
- * Returns maximum number of vertices face can consist of, e.g. 4 for regular quad mesh.
+ * Returns maximum number of vertices per face for this mesh, can consist of, e.g. 4 for regular quad mesh.
  */
 MDAL_EXPORT int MDAL_M_faceVerticesMaximumCount( MDAL_MeshH mesh );
 

--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -215,6 +215,11 @@ MDAL_EXPORT const char *MDAL_DR_longName( MDAL_DriverH driver );
  */
 MDAL_EXPORT const char *MDAL_DR_filters( MDAL_DriverH driver );
 
+/**
+ * Returns the maximum number of vertices per face supported by the driver
+ */
+MDAL_EXPORT int MDAL_DR_faceVerticesMaximumCount( MDAL_DriverH driver );
+
 ///////////////////////////////////////////////////////////////////////////////////////
 /// MESH
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -331,7 +336,7 @@ MDAL_EXPORT int MDAL_M_edgeCount( MDAL_MeshH mesh );
 MDAL_EXPORT int MDAL_M_faceCount( MDAL_MeshH mesh );
 
 /**
- * Returns maximum number of vertices face can consist of, e.g. 4 for regular quad mesh
+ * Returns maximum number of vertices face can consist of, e.g. 4 for regular quad mesh.
  */
 MDAL_EXPORT int MDAL_M_faceVerticesMaximumCount( MDAL_MeshH mesh );
 

--- a/mdal/frmts/mdal_ugrid.cpp
+++ b/mdal/frmts/mdal_ugrid.cpp
@@ -21,9 +21,7 @@ MDAL::DriverUgrid::DriverUgrid()
       "UGRID Results",
       "*.nc",
       Capability::ReadMesh | Capability::SaveMesh )
-{
-
-}
+{}
 
 MDAL::DriverUgrid *MDAL::DriverUgrid::create()
 {

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -171,6 +171,17 @@ const char *MDAL_DR_filters( MDAL_DriverH driver )
   return _return_str( d->filters() );
 }
 
+int MDAL_DR_faceVerticesMaximumCount( MDAL_DriverH driver )
+{
+  if ( !driver )
+  {
+    MDAL::Log::error( MDAL_Status::Err_MissingDriver, "Driver is not valid (null)" );
+    return -1;
+  }
+  MDAL::Driver *d = static_cast< MDAL::Driver * >( driver );
+  return d->faceVerticesMaximumCount();
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////
 /// MESH
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -1442,4 +1453,3 @@ void MDAL_M_setProjection( MDAL_MeshH mesh, const char *projection )
 
   static_cast<MDAL::Mesh *>( mesh )->setSourceCrsFromWKT( std::string( projection ) );
 }
-

--- a/tests/test_2dm.cpp
+++ b/tests/test_2dm.cpp
@@ -9,6 +9,16 @@
 #include "mdal_testutils.hpp"
 #include "mdal_utils.hpp"
 
+TEST( Mesh2DMTest, Driver )
+{
+  MDAL_DriverH driver = MDAL_driverFromName( "2DM" );
+  EXPECT_EQ( strcmp( MDAL_DR_filters( driver ), "*.2dm" ), 0 );
+  EXPECT_TRUE( MDAL_DR_meshLoadCapability( driver ) );
+  EXPECT_TRUE( MDAL_DR_saveMeshCapability( driver ) );
+  EXPECT_EQ( strcmp( MDAL_DR_saveMeshSuffix( driver ), "2dm" ), 0 );
+  EXPECT_EQ( MDAL_DR_faceVerticesMaximumCount( driver ), 6 );
+}
+
 TEST( Mesh2DMTest, MissingFile )
 {
   MDAL_MeshH m = MDAL_LoadMesh( "non/existent/path.2dm" );

--- a/tests/test_api.cpp
+++ b/tests/test_api.cpp
@@ -44,6 +44,7 @@ TEST( ApiTest, DriversApi )
   EXPECT_EQ( MDAL_DR_longName( nullptr ), std::string( "" ) );
   EXPECT_EQ( MDAL_DR_name( nullptr ), std::string( "" ) );
   EXPECT_EQ( MDAL_DR_filters( nullptr ), std::string( "" ) );
+  EXPECT_EQ( MDAL_DR_faceVerticesMaximumCount( nullptr ), -1 );
 }
 
 TEST( ApiTest, MeshApi )

--- a/tests/test_selafin.cpp
+++ b/tests/test_selafin.cpp
@@ -13,6 +13,16 @@
 #include "mdal_testutils.hpp"
 #include "frmts/mdal_selafin.hpp"
 
+TEST( MeshSLFTest, Driver )
+{
+  MDAL_DriverH driver = MDAL_driverFromName( "SELAFIN" );
+  EXPECT_EQ( strcmp( MDAL_DR_filters( driver ), "*.slf" ), 0 );
+  EXPECT_TRUE( MDAL_DR_meshLoadCapability( driver ) );
+  EXPECT_TRUE( MDAL_DR_saveMeshCapability( driver ) );
+  EXPECT_EQ( strcmp( MDAL_DR_saveMeshSuffix( driver ), "slf" ), 0 );
+  EXPECT_EQ( MDAL_DR_faceVerticesMaximumCount( driver ), 3 );
+}
+
 TEST( MeshSLFTest, MalpassetGeometry )
 {
   std::string path = test_file( "/slf/example.slf" );

--- a/tests/test_ugrid.cpp
+++ b/tests/test_ugrid.cpp
@@ -16,6 +16,16 @@
 #define M_PI 3.14159265358979323846264338327
 #endif
 
+TEST( MeshUgridTest, Driver )
+{
+  MDAL_DriverH driver = MDAL_driverFromName( "Ugrid" );
+  EXPECT_EQ( strcmp( MDAL_DR_filters( driver ), "*.nc" ), 0 );
+  EXPECT_TRUE( MDAL_DR_meshLoadCapability( driver ) );
+  EXPECT_TRUE( MDAL_DR_saveMeshCapability( driver ) );
+  EXPECT_EQ( strcmp( MDAL_DR_saveMeshSuffix( driver ), "nc" ), 0 );
+  EXPECT_EQ( MDAL_DR_faceVerticesMaximumCount( driver ), std::numeric_limits<int>::max() );
+}
+
 TEST( MeshUgridTest, SaveDFlow11Manzese )
 {
   saveAndCompareMesh(


### PR DESCRIPTION
Needed by QGIS when creating new file.
Before this PR, only the max vertices per face of a mesh can be provided (that is the max vertices for the actual faces).