### PR TITLE
fix 2DM write when face size > 4

### DIFF
--- a/mdal/frmts/mdal_2dm.cpp
+++ b/mdal/frmts/mdal_2dm.cpp
@@ -415,14 +415,16 @@ void MDAL::Driver2dm::save( const std::string &fileName, const std::string &, MD
   for ( size_t i = 0; i < mesh->facesCount(); ++i )
   {
     int faceOffsets[1];
-    faceIterator->next( 1, faceOffsets, 4, vertexIndices.data() );
+    faceIterator->next( 1, faceOffsets, 6, vertexIndices.data() );
 
-    if ( faceOffsets[0] > 2 && faceOffsets[0] < 5 )
+    if ( faceOffsets[0] > 2 && faceOffsets[0] < 7 )
     {
       if ( faceOffsets[0] == 3 )
         line = "E3T ";
       if ( faceOffsets[0] == 4 )
         line = "E4Q ";
+      if ( faceOffsets[0] == 5 ) //not in specification but added to avoid non saved mesh
+        line = "E5 ";
       if ( faceOffsets[0] == 6 )
         line = "E6T ";
 


### PR DESCRIPTION
Fixs to allow 2D save faces that have more than 4 vertices (up to 6 for reading).
Also allows face with 5 vertices, not such face in 2DM specification, but added here to avoid non saved mesh 
(for example created with mesh editing with QGIS)