### PR TITLE
fix flo2d rounding error

### DIFF
--- a/mdal/frmts/mdal_flo2d.cpp
+++ b/mdal/frmts/mdal_flo2d.cpp
@@ -818,8 +818,8 @@ void MDAL::DriverFlo2D::createMesh2d( const std::vector<CellCenter> &cells, cons
                      cellCenterExtent.minY - half_cell_size,
                      cellCenterExtent.maxY + half_cell_size );
 
-  size_t width = MDAL::toSizeT( ( vertexExtent.maxX - vertexExtent.minX ) / cell_size + 1 );
-  size_t heigh = MDAL::toSizeT( ( vertexExtent.maxY - vertexExtent.minY ) / cell_size + 1 );
+  size_t width = MDAL::toSizeT( ( vertexExtent.maxX - vertexExtent.minX ) / cell_size + 1.5 );
+  size_t heigh = MDAL::toSizeT( ( vertexExtent.maxY - vertexExtent.minY ) / cell_size + 1.5 );
   std::vector<std::vector<size_t>> vertexGrid( width, std::vector<size_t>( heigh, INVALID_INDEX ) );
 
   Vertices vertices;


### PR DESCRIPTION
alternative fix to #383

Issue came from a rounding error when calculating the the width/height of the mesh:
 `size_t(1542.9999 + 1 ) -> 1543` while the real width is 1544
with 
`size_t(1542.9999 + 1.5 ) -> 1544` -> ok in any cases

I think it is better to keep the old approach to populate the vertices. Indeed the new approach of #383 is quite slower.
Some tests test with files that leads to  #381, the time just to populate vertices (release build):
- #383: 150 ms
- old approach: 25 ms