### PR TITLE
Add extensions to SELAFIN driver

### DIFF
--- a/mdal/frmts/mdal_selafin.cpp
+++ b/mdal/frmts/mdal_selafin.cpp
@@ -615,7 +615,7 @@ void MDAL::SelafinFile::ignoreArrayLength( )
 MDAL::DriverSelafin::DriverSelafin():
   Driver( "SELAFIN",
           "Selafin File",
-          "*.slf",
+          "*.slf;;*.ser;;*.geo;;*.res",
           Capability::ReadMesh | Capability::SaveMesh | Capability::WriteDatasetsOnVertices | Capability::ReadDatasets
         )
 {

--- a/tests/test_selafin.cpp
+++ b/tests/test_selafin.cpp
@@ -16,7 +16,7 @@
 TEST( MeshSLFTest, Driver )
 {
   MDAL_DriverH driver = MDAL_driverFromName( "SELAFIN" );
-  EXPECT_EQ( strcmp( MDAL_DR_filters( driver ), "*.slf" ), 0 );
+  EXPECT_EQ( strcmp( MDAL_DR_filters( driver ), "*.slf;;*.ser;;*.geo;;*.res" ), 0 );
   EXPECT_TRUE( MDAL_DR_meshLoadCapability( driver ) );
   EXPECT_TRUE( MDAL_DR_saveMeshCapability( driver ) );
   EXPECT_EQ( strcmp( MDAL_DR_saveMeshSuffix( driver ), "slf" ), 0 );


### PR DESCRIPTION
This PR will allow QGIS to open more SELAFIN file with different extension.
As a single TELEMAC model is multi file, these added extensions are quite commonly used to differentiate files inside the model.

- `.ser` : SERAFIN, the other name of SELAFIN
- `.geo` : used for the geometry file (usually no dataset, juste the mesh)
- `.res` : the result file

Extension does not matter for TELEMAC. 