### PR TITLE
Fix format check for HEC-RAS.

### DIFF
--- a/mdal/frmts/mdal_hec2d.cpp
+++ b/mdal/frmts/mdal_hec2d.cpp
@@ -44,6 +44,11 @@ static HdfDataset openHdfDataset( const HdfGroup &hdfGroup, const std::string &n
   return dsFileType;
 }
 
+static bool existsHdfDataset( const HdfGroup &hdfGroup, const std::string &name )
+{
+  return hdfGroup.dataset( name ).isValid();
+}
+
 static std::string openHdfAttribute( const HdfFile &hdfFile, const std::string &name )
 {
   HdfAttribute attr = hdfFile.attribute( name );
@@ -761,12 +766,10 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverHec2D::load( const std::string &resultsF
   {
     HdfFile hdfFile = openHdfFile( mFileName );
 
-    // Verify it is correct file
-    std::string fileType = openHdfAttribute( hdfFile, "File Type" );
-    bool oldFormat = canReadOldFormat( fileType );
-
     HdfGroup gGeom = openHdfGroup( hdfFile, "Geometry" );
     HdfGroup gGeom2DFlowAreas = openHdfGroup( gGeom, "2D Flow Areas" );
+
+    bool oldFormat( existsHdfDataset( gGeom2DFlowAreas, "Names" ) );
 
     std::vector<std::string> flowAreaNames;
     if ( oldFormat )


### PR DESCRIPTION
I have a file with version "HEC-RAS 6.0.0 May 2021" that has file type "HEC-RAS Results", but uses the new way of storing flow area names.  This PR changes the format check to look for a "Names" dataset instead of checking the file type string.