### PR TITLE
Fix mesh file staying open in cf driver

### DIFF
--- a/mdal/frmts/mdal_cf.cpp
+++ b/mdal/frmts/mdal_cf.cpp
@@ -468,6 +468,7 @@ bool MDAL::DriverCF::canReadMesh( const std::string &uri )
     mNcFile.reset( new NetCDFFile );
     mNcFile->openFile( uri );
     populateDimensions( );
+    mNcFile.reset();
   }
   catch ( MDAL_Status )
   {


### PR DESCRIPTION
After loading a netcdf file it stays open because the driver will keep it open after calling DriverCF::canReadMesh.
fixes https://github.com/qgis/QGIS/issues/49215 