### PR TITLE
Fix xmdf lock

### DIFF
--- a/mdal/frmts/mdal_flo2d.cpp
+++ b/mdal/frmts/mdal_flo2d.cpp
@@ -1176,15 +1176,15 @@ bool MDAL::DriverFlo2D::saveNewHDF5File( DatasetGroup *dsGroup )
   if ( !file.isValid() ) return true;
 
   // Create float dataset File Version
-  HdfDataset dsFileVersion( file.id(), "/File Version", H5T_NATIVE_FLOAT );
+  HdfDataset dsFileVersion = file.dataset( "/File Version", H5T_NATIVE_FLOAT );
   dsFileVersion.write( 1.0f );
 
   // Create string dataset File Type
-  HdfDataset dsFileType( file.id(), "/File Type", HdfDataType::createString() );
+  HdfDataset dsFileType = file.dataset( "/File Type", HdfDataType::createString() );
   dsFileType.write( "Xmdf" );
 
   // Create group TIMDEP NETCDF OUTPUT RESULTS
-  HdfGroup groupTNOR = HdfGroup::create( file.id(), "/TIMDEP NETCDF OUTPUT RESULTS" );
+  HdfGroup groupTNOR = file.createGroup( "/TIMDEP NETCDF OUTPUT RESULTS" );
 
   // Create attribute
   HdfAttribute attTNORGrouptype( groupTNOR.id(), "Grouptype", HdfDataType::createString() );
@@ -1257,7 +1257,7 @@ bool MDAL::DriverFlo2D::appendGroup( HdfFile &file, MDAL::DatasetGroup *dsGroup,
   {
     dsGroupName = dsGroup->name() + "_" + std::to_string( i ); // make sure we have unique group name
   }
-  HdfGroup group = HdfGroup::create( groupTNOR.id(), "/TIMDEP NETCDF OUTPUT RESULTS/" + dsGroupName );
+  HdfGroup group = file.createGroup( "/TIMDEP NETCDF OUTPUT RESULTS/" + dsGroupName );
 
   HdfAttribute attDataType( group.id(), "Data Type", H5T_NATIVE_INT );
   attDataType.write( 0 );
@@ -1280,16 +1280,16 @@ bool MDAL::DriverFlo2D::appendGroup( HdfFile &file, MDAL::DatasetGroup *dsGroup,
   HdfAttribute attTimeUnits( group.id(), "TimeUnits", dtMaxString );
   attTimeUnits.write( "Hours" );
 
-  HdfDataset dsMaxs( file.id(), "/TIMDEP NETCDF OUTPUT RESULTS/" + dsGroupName + "/Maxs", H5T_NATIVE_FLOAT, timesCountVec );
+  HdfDataset dsMaxs = file.dataset( "/TIMDEP NETCDF OUTPUT RESULTS/" + dsGroupName + "/Maxs", H5T_NATIVE_FLOAT, timesCountVec );
   dsMaxs.write( maximums );
 
-  HdfDataset dsMins( file.id(), "/TIMDEP NETCDF OUTPUT RESULTS/" + dsGroupName + "/Mins", H5T_NATIVE_FLOAT, timesCountVec );
+  HdfDataset dsMins = file.dataset( "/TIMDEP NETCDF OUTPUT RESULTS/" + dsGroupName + "/Mins", H5T_NATIVE_FLOAT, timesCountVec );
   dsMins.write( minimums );
 
-  HdfDataset dsTimes( file.id(), "/TIMDEP NETCDF OUTPUT RESULTS/" + dsGroupName + "/Times", H5T_NATIVE_DOUBLE, timesCountVec );
+  HdfDataset dsTimes = file.dataset( "/TIMDEP NETCDF OUTPUT RESULTS/" + dsGroupName + "/Times", H5T_NATIVE_DOUBLE, timesCountVec );
   dsTimes.write( times );
 
-  HdfDataset dsValues( file.id(), "/TIMDEP NETCDF OUTPUT RESULTS/" + dsGroupName + "/Values", H5T_NATIVE_FLOAT, dscValues );
+  HdfDataset dsValues = file.dataset( "/TIMDEP NETCDF OUTPUT RESULTS/" + dsGroupName + "/Values", H5T_NATIVE_FLOAT, dscValues );
   dsValues.write( values );
 
   return false; //OK

--- a/mdal/frmts/mdal_hdf5.cpp
+++ b/mdal/frmts/mdal_hdf5.cpp
@@ -37,19 +37,15 @@ std::string HdfFile::filePath() const
   return mPath;
 }
 
-HdfGroup HdfGroup::create( hid_t file, const std::string &path )
+HdfGroup::HdfGroup( HdfFile::SharedHandle file, const std::string &path )
+  : mFile( file )
 {
-  auto d = std::make_shared< Handle >( H5Gcreate2( file, path.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ) );
-  return HdfGroup( d );
+  d = std::make_shared< Handle >( H5Gopen( file->id, path.c_str() ) );
 }
 
-HdfGroup::HdfGroup( hid_t file, const std::string &path )
-{
-  d = std::make_shared< Handle >( H5Gopen( file, path.c_str() ) );
-}
-
-HdfGroup::HdfGroup( std::shared_ptr<Handle> handle )
-  : d( handle )
+HdfGroup::HdfGroup( std::shared_ptr<Handle> handle, HdfFile::SharedHandle file )
+  : mFile( file )
+  , d( handle )
 {
 }
 
@@ -162,25 +158,28 @@ void HdfAttribute::write( int value )
     throw MDAL::Error( MDAL_Status::Err_FailToWriteToDisk, "Could not write data" );
 }
 
-HdfDataset::HdfDataset( hid_t file, const std::string &path, HdfDataType dtype, size_t nItems )
+HdfDataset::HdfDataset( HdfFile::SharedHandle file, const std::string &path, HdfDataType dtype, size_t nItems )
   : mType( dtype )
+  , mFile( file )
 {
   // Crete dataspace for attribute
   std::vector<hsize_t> dimsSingle = {nItems};
   HdfDataspace dsc( dimsSingle );
 
-  d = std::make_shared< Handle >( H5Dcreate2( file, path.c_str(), dtype.id(), dsc.id(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ) );
+  d = std::make_shared< Handle >( H5Dcreate2( file->id, path.c_str(), dtype.id(), dsc.id(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ) );
 }
 
 
-HdfDataset::HdfDataset( hid_t file, const std::string &path, HdfDataType dtype, HdfDataspace dataspace )
+HdfDataset::HdfDataset( HdfFile::SharedHandle file, const std::string &path, HdfDataType dtype, HdfDataspace dataspace )
   : mType( dtype )
+  , mFile( file )
 {
-  d = std::make_shared< Handle >( H5Dcreate2( file, path.c_str(), dtype.id(), dataspace.id(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ) );
+  d = std::make_shared< Handle >( H5Dcreate2( file->id, path.c_str(), dtype.id(), dataspace.id(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ) );
 }
 
-HdfDataset::HdfDataset( hid_t file, const std::string &path )
-  : d( std::make_shared< Handle >( H5Dopen2( file, path.c_str(), H5P_DEFAULT ) ) )
+HdfDataset::HdfDataset( HdfFile::SharedHandle file, const std::string &path )
+  : d( std::make_shared< Handle >( H5Dopen2( file->id, path.c_str(), H5P_DEFAULT ) ) )
+  , mFile( file )
 {
 }
 

--- a/mdal/frmts/mdal_hdf5.hpp
+++ b/mdal/frmts/mdal_hdf5.hpp
@@ -139,7 +139,7 @@ class HdfGroup
     HdfGroup( std::shared_ptr<Handle> handle, HdfFile::SharedHandle file );
 
   private:
-    HdfFile::SharedHandle mFile; //must be the last destroyed
+    HdfFile::SharedHandle mFile; //must be declared before "std::shared_ptr<Handle> d" to be sure it will be the last destroyed
 
   protected:
     std::shared_ptr<Handle> d;
@@ -300,7 +300,7 @@ class HdfDataset
     HdfDataset( HdfFile::SharedHandle file, const std::string &path );
 
   private:
-    HdfFile::SharedHandle mFile; //must be the last destroyed
+    HdfFile::SharedHandle mFile; //must be declared before "std::shared_ptr<Handle> d" to be sure it will be the last destroyed
 
   protected:
     std::shared_ptr<Handle> d;

--- a/mdal/frmts/mdal_hdf5.hpp
+++ b/mdal/frmts/mdal_hdf5.hpp
@@ -66,7 +66,7 @@ class HdfFile
       Create
     };
     typedef HdfH<H5I_FILE> Handle;
-    typedef std::shared_ptr<HdfH<H5I_FILE>> SharedHandle;
+    typedef std::shared_ptr<Handle> SharedHandle;
 
     HdfFile( const std::string &path, HdfFile::Mode mode );
     ~HdfFile();
@@ -129,10 +129,8 @@ class HdfGroup
 
     inline HdfGroup group( const std::string &groupName ) const;
     inline HdfDataset dataset( const std::string &dsName ) const;
-
     inline HdfAttribute attribute( const std::string &attr_name ) const;
     inline bool pathExists( const std::string &path ) const;
-
   protected:
     std::vector<std::string> objects( H5G_obj_t type ) const;
 
@@ -209,7 +207,6 @@ class HdfDataset
     //! creates invalid dataset
     HdfDataset() = default;
     ~HdfDataset();
-
     bool isValid() const;
     hid_t id() const;
 

--- a/mdal/frmts/mdal_hdf5.hpp
+++ b/mdal/frmts/mdal_hdf5.hpp
@@ -66,6 +66,7 @@ class HdfFile
       Create
     };
     typedef HdfH<H5I_FILE> Handle;
+    typedef std::shared_ptr<HdfH<H5I_FILE>> SharedHandle;
 
     HdfFile( const std::string &path, HdfFile::Mode mode );
     ~HdfFile();
@@ -75,15 +76,20 @@ class HdfFile
     inline std::vector<std::string> groups() const;
 
     inline HdfGroup group( const std::string &path ) const;
+    inline HdfGroup createGroup( const std::string &path ) const;
     inline HdfDataset dataset( const std::string &path ) const;
+    inline HdfDataset dataset( const std::string &path, HdfDataType dtype, size_t nItems = 1 ) const;
+    inline HdfDataset dataset( const std::string &path, HdfDataType dtype, HdfDataspace dataspace ) const;
     inline HdfAttribute attribute( const std::string &attr_name ) const;
     inline bool pathExists( const std::string &path ) const;
     std::string filePath() const;
 
   protected:
-    std::shared_ptr<Handle> d;
+    SharedHandle d;
     std::string mPath;
 };
+
+typedef std::shared_ptr<HdfFile> HdfFileShared;
 
 class HdfDataType
 {
@@ -109,10 +115,6 @@ class HdfGroup
   public:
     typedef HdfH<H5I_GROUP> Handle;
 
-    static HdfGroup create( hid_t file, const std::string &path );
-    HdfGroup( hid_t file, const std::string &path );
-    HdfGroup( std::shared_ptr<Handle> handle );
-
     bool isValid() const;
     hid_t id() const;
     hid_t file_id() const;
@@ -127,13 +129,24 @@ class HdfGroup
 
     inline HdfGroup group( const std::string &groupName ) const;
     inline HdfDataset dataset( const std::string &dsName ) const;
+
     inline HdfAttribute attribute( const std::string &attr_name ) const;
     inline bool pathExists( const std::string &path ) const;
+
   protected:
     std::vector<std::string> objects( H5G_obj_t type ) const;
 
+  private:
+    HdfGroup( HdfFile::SharedHandle file, const std::string &path );
+    HdfGroup( std::shared_ptr<Handle> handle, HdfFile::SharedHandle file );
+
+  private:
+    HdfFile::SharedHandle mFile; //must be the last destroyed
+
   protected:
     std::shared_ptr<Handle> d;
+
+    friend class HdfFile;
 };
 
 class HdfAttribute
@@ -195,14 +208,8 @@ class HdfDataset
 
     //! creates invalid dataset
     HdfDataset() = default;
-
-    //! Creates new, simple 1 dimensional dataset
-    HdfDataset( hid_t file, const std::string &path, HdfDataType dtype, size_t nItems = 1 );
-    //! Creates new dataset with custom dimensions
-    HdfDataset( hid_t file, const std::string &path, HdfDataType dtype, HdfDataspace dataspace );
-    //! Opens dataset for reading
-    HdfDataset( hid_t file, const std::string &path );
     ~HdfDataset();
+
     bool isValid() const;
     hid_t id() const;
 
@@ -287,20 +294,43 @@ class HdfDataset
     //! Writes array of double data
     void write( std::vector<double> &value );
 
+  private:
+    //! Creates new, simple 1 dimensional dataset
+    HdfDataset( HdfFile::SharedHandle file, const std::string &path, HdfDataType dtype, size_t nItems = 1 );
+    //! Creates new dataset with custom dimensions
+    HdfDataset( HdfFile::SharedHandle file, const std::string &path, HdfDataType dtype, HdfDataspace dataspace );
+    //! Opens dataset for reading
+    HdfDataset( HdfFile::SharedHandle file, const std::string &path );
+
+  private:
+    HdfFile::SharedHandle mFile; //must be the last destroyed
+
   protected:
     std::shared_ptr<Handle> d;
     HdfDataType mType; // when in write mode
+
+    friend class HdfFile;
+    friend class HdfGroup;
 };
 
 inline std::vector<std::string> HdfFile::groups() const { return group( "/" ).groups(); }
 
-inline HdfGroup HdfFile::group( const std::string &path ) const { return HdfGroup( d->id, path ); }
+inline HdfGroup HdfFile::group( const std::string &path ) const { return HdfGroup( d, path ); }
 
-inline HdfDataset HdfFile::dataset( const std::string &path ) const { return HdfDataset( d->id, path ); }
+inline HdfGroup HdfFile::createGroup( const std::string &path ) const
+{
+  return HdfGroup( std::make_shared< HdfGroup::Handle >( H5Gcreate2( d->id, path.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT ) ), d );
+}
 
-inline HdfGroup HdfGroup::group( const std::string &groupName ) const { return HdfGroup( file_id(), childPath( groupName ) ); }
+inline HdfDataset HdfFile::dataset( const std::string &path ) const { return HdfDataset( d, path ); }
 
-inline HdfDataset HdfGroup::dataset( const std::string &dsName ) const { return HdfDataset( file_id(), childPath( dsName ) ); }
+inline HdfDataset HdfFile::dataset( const std::string &path, HdfDataType dtype, size_t nItems ) const { return HdfDataset( d, path, dtype, nItems ); }
+
+inline HdfDataset HdfFile::dataset( const std::string &path, HdfDataType dtype, HdfDataspace dataspace ) const {return HdfDataset( d, path, dtype, dataspace );}
+
+inline HdfGroup HdfGroup::group( const std::string &groupName ) const { return HdfGroup( mFile, childPath( groupName ) ); }
+
+inline HdfDataset HdfGroup::dataset( const std::string &dsName ) const { return HdfDataset( mFile, childPath( dsName ) ); }
 
 inline bool HdfDataset::hasAttribute( const std::string &attr_name ) const
 {

--- a/mdal/frmts/mdal_xdmf.cpp
+++ b/mdal/frmts/mdal_xdmf.cpp
@@ -338,8 +338,7 @@ HdfDataset MDAL::DriverXdmf::parseHdf5Node( const XMLFile &xmfFile, xmlNodePtr n
     hdfFile = mHdfFiles[hdf5Name];
   }
 
-  HdfDataset hdfDataset( hdfFile->id(), hdf5Path );
-  return hdfDataset;
+  return hdfFile->dataset( hdf5Path );
 }
 
 void MDAL::DriverXdmf::hdf5NamePath( const std::string &dataItemPath, std::string &filePath, std::string &hdf5Path )

--- a/tests/test_xmdf.cpp
+++ b/tests/test_xmdf.cpp
@@ -299,25 +299,25 @@ TEST( MeshXmdfTest, withReferenceTime )
   MDAL_CloseMesh( m );
 }
 
-TEST(MeshXmdfTest, unlockWhenClose)
+TEST( MeshXmdfTest, unlockWhenClose )
 {
-    std::string tmpXmdf = tmp_file("temp.xmdf");
-    copy(test_file("/xmdf/withReferenceTime/PTM_005_QGIS_Axis.xmdf"), tmpXmdf);
+  std::string tmpXmdf = tmp_file( "temp.xmdf" );
+  copy( test_file( "/xmdf/withReferenceTime/PTM_005_QGIS_Axis.xmdf" ), tmpXmdf );
 
-    ASSERT_TRUE(fileExists(tmpXmdf));
+  ASSERT_TRUE( fileExists( tmpXmdf ) );
 
-    std::string path = test_file("/xmdf/withReferenceTime/hydraul_006.2dm");
-    EXPECT_EQ(MDAL_MeshNames(path.c_str()), "2DM:\"" + path + "\"");
-    MDAL_MeshH m = MDAL_LoadMesh(path.c_str());
-    ASSERT_NE(m, nullptr);
-    MDAL_M_LoadDatasets(m, tmpXmdf.c_str());
-    ASSERT_EQ(12, MDAL_M_datasetGroupCount(m));
+  std::string path = test_file( "/xmdf/withReferenceTime/hydraul_006.2dm" );
+  EXPECT_EQ( MDAL_MeshNames( path.c_str() ), "2DM:\"" + path + "\"" );
+  MDAL_MeshH m = MDAL_LoadMesh( path.c_str() );
+  ASSERT_NE( m, nullptr );
+  MDAL_M_LoadDatasets( m, tmpXmdf.c_str() );
+  ASSERT_EQ( 12, MDAL_M_datasetGroupCount( m ) );
 
-    MDAL_CloseMesh(m);
+  MDAL_CloseMesh( m );
 
-    deleteFile(tmpXmdf);
+  deleteFile( tmpXmdf );
 
-    ASSERT_FALSE(fileExists(tmpXmdf));
+  ASSERT_FALSE( fileExists( tmpXmdf ) );
 }
 
 TEST( MeshXmdfTest, HydroAs2D )

--- a/tests/test_xmdf.cpp
+++ b/tests/test_xmdf.cpp
@@ -299,6 +299,27 @@ TEST( MeshXmdfTest, withReferenceTime )
   MDAL_CloseMesh( m );
 }
 
+TEST(MeshXmdfTest, unlockWhenClose)
+{
+    std::string tmpXmdf = tmp_file("temp.xmdf");
+    copy(test_file("/xmdf/withReferenceTime/PTM_005_QGIS_Axis.xmdf"), tmpXmdf);
+
+    ASSERT_TRUE(fileExists(tmpXmdf));
+
+    std::string path = test_file("/xmdf/withReferenceTime/hydraul_006.2dm");
+    EXPECT_EQ(MDAL_MeshNames(path.c_str()), "2DM:\"" + path + "\"");
+    MDAL_MeshH m = MDAL_LoadMesh(path.c_str());
+    ASSERT_NE(m, nullptr);
+    MDAL_M_LoadDatasets(m, tmpXmdf.c_str());
+    ASSERT_EQ(12, MDAL_M_datasetGroupCount(m));
+
+    MDAL_CloseMesh(m);
+
+    deleteFile(tmpXmdf);
+
+    ASSERT_FALSE(fileExists(tmpXmdf));
+}
+
 TEST( MeshXmdfTest, HydroAs2D )
 {
   std::string path = test_file( "/xmdf/hydro-as-2d/hydro_as-2d.2dm" );


### PR DESCRIPTION
For Xmdf format, when the mesh is closed (for example, removed from QGIS), the files is still locked as it is still open, and user is unable to rename or remove the file until QGIS is closed.

Indeed, the mesh is not closed properly because the file's handle is closed before the dataset's handle are closed, leading to keep the file open.

To close the mesh properly it necessary to close the file's handle once every other Hdf5 handles are closed. To achieve this, a "shared file's handle" is embeded in each HdFGroup and each HdfDataset. This member is declared before the group/dataset handle to be sure the shared handle is destroy once the group/dataset handle is effectively closed.
The destruction of the last shared handle leads to close the file.

To improve the encapsulation around HdfFile, some refactorization are also done.