### PR TITLE
Bump googletest to fix build issue

### DIFF
--- a/tests/GTestCMakeLists.in
+++ b/tests/GTestCMakeLists.in
@@ -7,7 +7,7 @@ PROJECT(googletest-download NONE)
 INCLUDE(ExternalProject)
 EXTERNALPROJECT_ADD(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.8.1
+    GIT_TAG release-1.11.0
     SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-src"
     BINARY_DIR "${CMAKE_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
I got an error during buillding the included library "googletest" with GCC 11.

Bumping googletest fixed it.

Ref. ['dummy' may be used uninitialized](https://stackoverflow.com/questions/69935158/dummy-may-be-used-uninitialized) and https://github.com/google/googletest/pull/3024