### PR TITLE
Fix#391

### DIFF
--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   coverage_tests:
     if: github.repository == 'lutraconsulting/MDAL'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout MDAL
         uses: actions/checkout@v2

--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -2,7 +2,7 @@ name: Linux Tests
 on: [push, pull_request]
 jobs:
   linux_tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout MDAL
         uses: actions/checkout@v2

--- a/.github/workflows/memcheck_tests.yml
+++ b/.github/workflows/memcheck_tests.yml
@@ -2,7 +2,7 @@ name: MemCheck Tests
 on: [push, pull_request]
 jobs:
   memcheck_tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout MDAL
         uses: actions/checkout@v2

--- a/.github/workflows/osx_tests.yml
+++ b/.github/workflows/osx_tests.yml
@@ -1,7 +1,7 @@
 name: OSX Tests
 on: [push, pull_request]
 env:
-  QGIS_DEPS_VERSION: 0.9.0
+  QGIS_DEPS_VERSION: 0.4.0
 jobs:
   osx_tests:
     runs-on: macos-latest

--- a/.github/workflows/osx_tests.yml
+++ b/.github/workflows/osx_tests.yml
@@ -1,7 +1,7 @@
 name: OSX Tests
 on: [push, pull_request]
 env:
-  QGIS_DEPS_VERSION: 0.4.0
+  QGIS_DEPS_VERSION: 0.9.0
 jobs:
   osx_tests:
     runs-on: macos-latest

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -3,21 +3,17 @@ on: [push, pull_request]
 
 jobs:
   windows_tests:
-    runs-on: windows-2022
+    runs-on: windows-latest
 
     steps:
       - name: Checkout MDAL
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        
+      - name: config env variables
+        run:  echo "OSGEO4W_ROOT=${{github.workspace}}\OSGEO4W" >> $env:GITHUB_ENV
 
-      - name: Choco install qgis
-        uses: crazy-max/ghaction-chocolatey@v1
-        with:
-          args: install qgis-ltr -y --verbose --version=3.22.13
-
-      - name: Move SDK to OSGeo4W folder
-        shell: pwsh
-        run: |
-            mv "C:\Program Files\QGIS 3.22.13" "C:\OSGeo4W64"
+      - name: load OSGEO dependencies
+        run: ${{github.workspace}}/scripts/load_osgeo.ps1
 
       - name: Set compiler environment
         shell: cmd
@@ -38,7 +34,7 @@ jobs:
             cd $env:GITHUB_WORKSPACE
             mkdir build
             cd build
-            exec { cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Rel  -DENABLE_TESTS=ON  -DEXTERNAL_DRIVER_DHI_DFS=OFF -DNETCDF_PREFIX="C:\OSGeo4W64" -DHDF5_ROOT="C:\OSGeo4W64" -DGDAL_DIR="C:\OSGeo4W64" -DGDAL_LIBRARY="C:\OSGeo4W64\lib\gdal_i.lib" -DGDAL_INCLUDE_DIR="C:\OSGeo4W64\include" -DLIBXML2_LIBRARIES="C:\OSGeo4W64\lib\libxml2.lib" -DLIBXML2_INCLUDE_DIR="C:\OSGeo4W64\include\libxml2" ..  }
+            exec { cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Rel  -DENABLE_TESTS=ON  -DEXTERNAL_DRIVER_DHI_DFS=OFF -DNETCDF_PREFIX=${{env.OSGEO4W_ROOT}} -DHDF5_ROOT=${{env.OSGEO4W_ROOT}} -DGDAL_DIR="${{env.OSGEO4W_ROOT}} -DGDAL_LIBRARY="${{env.OSGEO4W_ROOT}}\lib\gdal_i.lib" -DGDAL_INCLUDE_DIR="${{env.OSGEO4W_ROOT}}\include" -DLIBXML2_LIBRARIES="${{env.OSGEO4W_ROOT}}\libxml2.lib" -DLIBXML2_INCLUDE_DIR="${{env.OSGEO4W_ROOT}}\include\libxml2" ..  }
             exec { cmake --build . }
 
       - name: Run tests
@@ -52,7 +48,7 @@ jobs:
                 if ($LastExitCode -ne 0) { exit $LastExitCode }
             }
 
-            $env:PATH="C:\OSGeo4W64\bin;$env:GITHUB_WORKSPACE\build\tool\Debug\;$env:GITHUB_WORKSPACE\build\mdal\Debug;$env:PATH"
+            $env:PATH="C${{env.OSGEO4W_ROOT}}\bin;$env:GITHUB_WORKSPACE\build\tool\Debug\;$env:GITHUB_WORKSPACE\build\mdal\Debug;$env:PATH"
             $env:MDAL_DRIVER_PATH="$env:GITHUB_WORKSPACE\build\external_drivers\minimal_example\Debug"
             cd $env:GITHUB_WORKSPACE\build
             exec { ctest -VV --exclude-regex "mdalinfo_test" }

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Choco install qgis
         uses: crazy-max/ghaction-chocolatey@v1
         with:
-          args: install qgis -y --verbose --version=3.22.13
+          args: install qgis-ltr -y --verbose --version=3.22.13
 
       - name: Move SDK to OSGeo4W folder
         shell: pwsh

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Move SDK to OSGeo4W folder
         shell: pwsh
         run: |
-            mv "C:\Program Files\QGIS 3.22" "C:\OSGeo4W64"
+            mv "C:\Program Files\QGIS 3.22.13" "C:\OSGeo4W64"
 
       - name: Set compiler environment
         shell: cmd

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -34,7 +34,7 @@ jobs:
             cd $env:GITHUB_WORKSPACE
             mkdir build
             cd build
-            exec { cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Rel  -DENABLE_TESTS=ON  -DEXTERNAL_DRIVER_DHI_DFS=OFF -DNETCDF_PREFIX=${{env.OSGEO4W_ROOT}} -DHDF5_ROOT=${{env.OSGEO4W_ROOT}} -DGDAL_DIR=${{env.OSGEO4W_ROOT}} -DGDAL_LIBRARY="${{env.OSGEO4W_ROOT}}\lib\gdal_i.lib" -DGDAL_INCLUDE_DIR="${{env.OSGEO4W_ROOT}}\include" -DLIBXML2_LIBRARIES="${{env.OSGEO4W_ROOT}}\libxml2.lib" -DLIBXML2_INCLUDE_DIR="${{env.OSGEO4W_ROOT}}\include\libxml2" ..  }
+            exec { cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Rel  -DENABLE_TESTS=ON  -DEXTERNAL_DRIVER_DHI_DFS=OFF -DNETCDF_PREFIX=${{env.OSGEO4W_ROOT}} -DHDF5_ROOT=${{env.OSGEO4W_ROOT}} -DGDAL_DIR=${{env.OSGEO4W_ROOT}} -DGDAL_LIBRARY="${{env.OSGEO4W_ROOT}}\lib\gdal_i.lib" -DGDAL_INCLUDE_DIR="${{env.OSGEO4W_ROOT}}\include" -DLIBXML2_LIBRARIES="${{env.OSGEO4W_ROOT}}\lib\libxml2.lib" -DLIBXML2_INCLUDE_DIR="${{env.OSGEO4W_ROOT}}\include\libxml2" ..  }
             exec { cmake --build . }
 
       - name: Run tests

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -48,7 +48,7 @@ jobs:
                 if ($LastExitCode -ne 0) { exit $LastExitCode }
             }
 
-            $env:PATH="C${{env.OSGEO4W_ROOT}}\bin;$env:GITHUB_WORKSPACE\build\tool\Debug\;$env:GITHUB_WORKSPACE\build\mdal\Debug;$env:PATH"
+            $env:PATH="${{env.OSGEO4W_ROOT}}\bin;$env:GITHUB_WORKSPACE\build\tool\Debug\;$env:GITHUB_WORKSPACE\build\mdal\Debug;$env:PATH"
             $env:MDAL_DRIVER_PATH="$env:GITHUB_WORKSPACE\build\external_drivers\minimal_example\Debug"
             cd $env:GITHUB_WORKSPACE\build
             exec { ctest -VV --exclude-regex "mdalinfo_test" }

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -34,7 +34,7 @@ jobs:
             cd $env:GITHUB_WORKSPACE
             mkdir build
             cd build
-            exec { cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Rel  -DENABLE_TESTS=ON  -DEXTERNAL_DRIVER_DHI_DFS=OFF -DNETCDF_PREFIX=${{env.OSGEO4W_ROOT}} -DHDF5_ROOT=${{env.OSGEO4W_ROOT}} -DGDAL_DIR="${{env.OSGEO4W_ROOT}} -DGDAL_LIBRARY="${{env.OSGEO4W_ROOT}}\lib\gdal_i.lib" -DGDAL_INCLUDE_DIR="${{env.OSGEO4W_ROOT}}\include" -DLIBXML2_LIBRARIES="${{env.OSGEO4W_ROOT}}\libxml2.lib" -DLIBXML2_INCLUDE_DIR="${{env.OSGEO4W_ROOT}}\include\libxml2" ..  }
+            exec { cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Rel  -DENABLE_TESTS=ON  -DEXTERNAL_DRIVER_DHI_DFS=OFF -DNETCDF_PREFIX=${{env.OSGEO4W_ROOT}} -DHDF5_ROOT=${{env.OSGEO4W_ROOT}} -DGDAL_DIR=${{env.OSGEO4W_ROOT}} -DGDAL_LIBRARY="${{env.OSGEO4W_ROOT}}\lib\gdal_i.lib" -DGDAL_INCLUDE_DIR="${{env.OSGEO4W_ROOT}}\include" -DLIBXML2_LIBRARIES="${{env.OSGEO4W_ROOT}}\libxml2.lib" -DLIBXML2_INCLUDE_DIR="${{env.OSGEO4W_ROOT}}\include\libxml2" ..  }
             exec { cmake --build . }
 
       - name: Run tests

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -12,12 +12,12 @@ jobs:
       - name: Choco install qgis
         uses: crazy-max/ghaction-chocolatey@v1
         with:
-          args: install qgis -y --verbose --version=3.16.3
+          args: install qgis -y --verbose --version=3.22.13
 
       - name: Move SDK to OSGeo4W folder
         shell: pwsh
         run: |
-            mv "C:\Program Files\QGIS 3.16" "C:\OSGeo4W64"
+            mv "C:\Program Files\QGIS 3.22" "C:\OSGeo4W64"
 
       - name: Set compiler environment
         shell: cmd

--- a/mdal/frmts/mdal_gdal.cpp
+++ b/mdal/frmts/mdal_gdal.cpp
@@ -90,7 +90,7 @@ bool MDAL::DriverGdal::initVertices( Vertices &vertices )
   }
 
 //until GDAL >= 4.3 is used by macos see https://github.com/lutraconsulting/MDAL/pull/439
-#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
+//#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
   BBox extent = computeExtent( vertices );
   // we want to detect situation when there is whole earth represented in dataset
   bool is_longitude_shifted = ( extent.minX >= 0.0 ) &&
@@ -111,16 +111,16 @@ bool MDAL::DriverGdal::initVertices( Vertices &vertices )
   }
 
   return is_longitude_shifted;
-#else
-  return false;
-#endif
+//#else
+//  return false;
+//#endif
 }
 
 void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is_longitude_shifted )
 {
-#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
+//#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
   int reconnected = 0;
-#endif
+//#endif
   unsigned int mXSize = meshGDALDataset()->mXSize;
   unsigned int mYSize = meshGDALDataset()->mYSize;
 
@@ -130,8 +130,8 @@ void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is
   {
     for ( unsigned int x = 0; x < mXSize - 1; ++x )
     {
-//until GDAL >= 4.3 is used by macos see https://github.com/lutraconsulting/MDAL/pull/439
-#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
+//https://github.com/lutraconsulting/MDAL/issues/391
+//#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
       if ( is_longitude_shifted &&
            ( Vertexs[x + mXSize * y].x > 0.0 ) &&
            ( Vertexs[x + 1 + mXSize * y].x < 0.0 ) )
@@ -153,7 +153,7 @@ void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is
         ++reconnected;
         ++i;
       }
-#endif
+//#endif
 
       // other faces
       Faces[i].resize( 4 );
@@ -165,10 +165,10 @@ void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is
       ++i;
     }
   }
-#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
+//#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
   //make sure we have discarded same amount of faces that we have added
   assert( reconnected == 0 );
-#endif
+//#endif
 }
 
 std::string MDAL::DriverGdal::GDALFileName( const std::string &fileName )

--- a/mdal/frmts/mdal_gdal.cpp
+++ b/mdal/frmts/mdal_gdal.cpp
@@ -89,8 +89,6 @@ bool MDAL::DriverGdal::initVertices( Vertices &vertices )
     }
   }
 
-//until GDAL >= 4.3 is used by macos see https://github.com/lutraconsulting/MDAL/pull/439
-//#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
   BBox extent = computeExtent( vertices );
   // we want to detect situation when there is whole earth represented in dataset
   bool is_longitude_shifted = ( extent.minX >= 0.0 ) &&
@@ -111,16 +109,11 @@ bool MDAL::DriverGdal::initVertices( Vertices &vertices )
   }
 
   return is_longitude_shifted;
-//#else
-//  return false;
-//#endif
 }
 
 void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is_longitude_shifted )
 {
-//#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
   int reconnected = 0;
-//#endif
   unsigned int mXSize = meshGDALDataset()->mXSize;
   unsigned int mYSize = meshGDALDataset()->mYSize;
 
@@ -130,8 +123,6 @@ void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is
   {
     for ( unsigned int x = 0; x < mXSize - 1; ++x )
     {
-//https://github.com/lutraconsulting/MDAL/issues/391
-//#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
       if ( is_longitude_shifted &&
            ( Vertexs[x + mXSize * y].x > 0.0 ) &&
            ( Vertexs[x + 1 + mXSize * y].x < 0.0 ) )
@@ -153,7 +144,6 @@ void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is
         ++reconnected;
         ++i;
       }
-//#endif
 
       // other faces
       Faces[i].resize( 4 );
@@ -165,10 +155,7 @@ void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is
       ++i;
     }
   }
-//#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
-  //make sure we have discarded same amount of faces that we have added
   assert( reconnected == 0 );
-//#endif
 }
 
 std::string MDAL::DriverGdal::GDALFileName( const std::string &fileName )
@@ -599,7 +586,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverGdal::load( const std::string &fileName,
       }
     }
 
-    for ( std::shared_ptr<MDAL::GdalDataset> ds : datasets )
+    for ( std::shared_ptr<MDAL::GdalDataset> &ds : datasets )
       if ( gdal_datasets.empty() || meshes_equals( meshGDALDataset(), ds.get() ) )
         gdal_datasets.push_back( ds );
 

--- a/mdal/frmts/mdal_gdal.cpp
+++ b/mdal/frmts/mdal_gdal.cpp
@@ -155,6 +155,7 @@ void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is
       ++i;
     }
   }
+  //make sure we have discarded same amount of faces that we have added
   assert( reconnected == 0 );
 }
 

--- a/mdal/frmts/mdal_gdal.cpp
+++ b/mdal/frmts/mdal_gdal.cpp
@@ -90,7 +90,7 @@ bool MDAL::DriverGdal::initVertices( Vertices &vertices )
   }
 
 //until GDAL >= 4.3 is used by macos see https://github.com/lutraconsulting/MDAL/pull/439
-#if (defined(__APPLE__) && defined(__MACH__))
+#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
   BBox extent = computeExtent( vertices );
   // we want to detect situation when there is whole earth represented in dataset
   bool is_longitude_shifted = ( extent.minX >= 0.0 ) &&
@@ -118,7 +118,7 @@ bool MDAL::DriverGdal::initVertices( Vertices &vertices )
 
 void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is_longitude_shifted )
 {
-#if (defined(__APPLE__) && defined(__MACH__))
+#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
   int reconnected = 0;
 #endif
   unsigned int mXSize = meshGDALDataset()->mXSize;
@@ -131,7 +131,7 @@ void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is
     for ( unsigned int x = 0; x < mXSize - 1; ++x )
     {
 //until GDAL >= 4.3 is used by macos see https://github.com/lutraconsulting/MDAL/pull/439
-#if (defined(__APPLE__) && defined(__MACH__))
+#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
       if ( is_longitude_shifted &&
            ( Vertexs[x + mXSize * y].x > 0.0 ) &&
            ( Vertexs[x + 1 + mXSize * y].x < 0.0 ) )
@@ -165,7 +165,7 @@ void MDAL::DriverGdal::initFaces( const Vertices &Vertexs, Faces &Faces, bool is
       ++i;
     }
   }
-#if (defined(__APPLE__) && defined(__MACH__))
+#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
   //make sure we have discarded same amount of faces that we have added
   assert( reconnected == 0 );
 #endif

--- a/mdal/frmts/mdal_gdal.hpp
+++ b/mdal/frmts/mdal_gdal.hpp
@@ -79,7 +79,7 @@ namespace MDAL
 
       void registerDriver();
 
-      void initFaces( Vertices &nodes, Faces &Faces, bool is_longitude_shifted );
+      void initFaces( const Vertices &nodes, Faces &Faces, bool is_longitude_shifted );
       bool initVertices( Vertices &vertices ); //returns is_longitude_shifted
 
       const GdalDataset *meshGDALDataset();

--- a/scripts/load_osgeo.ps1
+++ b/scripts/load_osgeo.ps1
@@ -1,0 +1,49 @@
+# from https://gist.github.com/Guts/6303dc5eb941eb24be3e27609cd46985
+
+$starter_path = Get-Location
+
+md $env:OSGEO4W_ROOT
+
+# Download installer if not exists
+if (-Not (Test-Path "$env:OSGEO4W_ROOT\osgeo4w-setup.exe" -PathType leaf )) {
+   Write-Host "= Start downloading the OSGeo4W installer"
+   Invoke-WebRequest -Uri "https://download.osgeo.org/osgeo4w/v2/osgeo4w-setup.exe" -OutFile "$env:OSGEO4W_ROOT\osgeo4w-setup.exe"
+   if (Test-Path "$env:OSGEO4W_ROOT\osgeo4w-setup.exe" -PathType leaf)
+   {
+       Write-Host "== Installer downloaded"
+   }
+   else
+   {
+       Write-Host "== Installer not downloaded"
+   }
+}
+else
+{ Write-Host "= OSGeo4W installer already exists. Let's use it!" -ForegroundColor Blue }
+
+Set-Location $env:OSGEO4W_ROOT
+
+# Install OSGEodep
+Write-Host "=== Start installing OSGEO dependencies..."
+Write-Host "=== Destination:"
+$env:OSGEO4W_ROOT
+Write-Host "================================================="
+
+.\osgeo4w-setup.exe `
+    --advanced `
+    --arch x86_64 `
+    --autoaccept `
+    --delete-orphans `
+    --local-package-dir "$env:APPDATA/OSGeo4W-Packages" `
+    --menu-name "QGIS LTR" `
+    --no-desktop `
+    --packages qgis-deps `
+    --root $env:OSGEO4W_ROOT `
+    --quiet-mode `
+    --site "http://download.osgeo.org/osgeo4w/v2" `
+    --upgrade-also `
+| out-null
+
+Write-Host "=== Finished installing OSGEO dependencies..."
+
+Set-Location $starter_path
+

--- a/tests/test_gdal_grib.cpp
+++ b/tests/test_gdal_grib.cpp
@@ -212,7 +212,7 @@ TEST( MeshGdalGribTest, ScalarFileWithUComponent )
 
   double value = getValue( ds, 1600 );
 #if (defined(__APPLE__) && defined(__MACH__))
-  EXPECT_DOUBLE_EQ( -0.818756103515625, value ); //until GDAL >= 4.3 is used with macos see https://github.com/lutraconsulting/MDAL/pull/439
+  EXPECT_DOUBLE_EQ( -0.818756103515625, value ); //until GDAL >= 4.3 is used by macos see https://github.com/lutraconsulting/MDAL/pull/439
 # else
   EXPECT_DOUBLE_EQ( -0.535552978515625, value );
 #endif

--- a/tests/test_gdal_grib.cpp
+++ b/tests/test_gdal_grib.cpp
@@ -211,7 +211,7 @@ TEST( MeshGdalGribTest, ScalarFileWithUComponent )
   ASSERT_EQ( 115680, count );
 
   double value = getValue( ds, 1600 );
-  EXPECT_DOUBLE_EQ( -0.818756103515625, value );
+  EXPECT_DOUBLE_EQ( -0.535552978515625, value );
 
   EXPECT_TRUE( compareReferenceTime( g, "2018-10-01T00:00:00" ) );
 

--- a/tests/test_gdal_grib.cpp
+++ b/tests/test_gdal_grib.cpp
@@ -211,7 +211,7 @@ TEST( MeshGdalGribTest, ScalarFileWithUComponent )
   ASSERT_EQ( 115680, count );
 
   double value = getValue( ds, 1600 );
-#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
+#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0) //https://github.com/lutraconsulting/MDAL/issues/391
   EXPECT_DOUBLE_EQ( -0.818756103515625, value ); //until GDAL >= 4.3 is used by macos see https://github.com/lutraconsulting/MDAL/pull/439
 # else
   EXPECT_DOUBLE_EQ( -0.535552978515625, value );

--- a/tests/test_gdal_grib.cpp
+++ b/tests/test_gdal_grib.cpp
@@ -212,7 +212,7 @@ TEST( MeshGdalGribTest, ScalarFileWithUComponent )
 
   double value = getValue( ds, 1600 );
 #if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0) //https://github.com/lutraconsulting/MDAL/issues/391
-  EXPECT_DOUBLE_EQ( -0.818756103515625, value ); //until GDAL >= 4.3 is used by macos see https://github.com/lutraconsulting/MDAL/pull/439
+  EXPECT_DOUBLE_EQ( -0.818756103515625, value );
 # else
   EXPECT_DOUBLE_EQ( -0.535552978515625, value );
 #endif

--- a/tests/test_gdal_grib.cpp
+++ b/tests/test_gdal_grib.cpp
@@ -212,7 +212,7 @@ TEST( MeshGdalGribTest, ScalarFileWithUComponent )
 
   double value = getValue( ds, 1600 );
 #if (defined(__APPLE__) && defined(__MACH__))
-  EXPECT_DOUBLE_EQ( -0.818756103515625, value ); //until GDAL >= 4.3 is used with macos
+  EXPECT_DOUBLE_EQ( -0.818756103515625, value ); //until GDAL >= 4.3 is used with macos see https://github.com/lutraconsulting/MDAL/pull/439
 # else
   EXPECT_DOUBLE_EQ( -0.535552978515625, value );
 #endif

--- a/tests/test_gdal_grib.cpp
+++ b/tests/test_gdal_grib.cpp
@@ -211,7 +211,11 @@ TEST( MeshGdalGribTest, ScalarFileWithUComponent )
   ASSERT_EQ( 115680, count );
 
   double value = getValue( ds, 1600 );
+#if (defined(__APPLE__) && defined(__MACH__))
+  EXPECT_DOUBLE_EQ( -0.818756103515625, value ); //until GDAL >= 4.3 is used with macos
+# else
   EXPECT_DOUBLE_EQ( -0.535552978515625, value );
+#endif
 
   EXPECT_TRUE( compareReferenceTime( g, "2018-10-01T00:00:00" ) );
 

--- a/tests/test_gdal_grib.cpp
+++ b/tests/test_gdal_grib.cpp
@@ -211,7 +211,7 @@ TEST( MeshGdalGribTest, ScalarFileWithUComponent )
   ASSERT_EQ( 115680, count );
 
   double value = getValue( ds, 1600 );
-#if (defined(__APPLE__) && defined(__MACH__))
+#if defined( GDAL_VERSION_NUM ) && GDAL_VERSION_NUM< GDAL_COMPUTE_VERSION(3,4,0)
   EXPECT_DOUBLE_EQ( -0.818756103515625, value ); //until GDAL >= 4.3 is used by macos see https://github.com/lutraconsulting/MDAL/pull/439
 # else
   EXPECT_DOUBLE_EQ( -0.535552978515625, value );


### PR DESCRIPTION
Time to go ahead with GDAL >=3.4, and test using ubuntu latest

For windows, tests are done after loading dependencies from OSGEO instead of chocolatey.

For macos, not sure GDAL >=3.4 is easily available (@PeterPetrik ?), sor for now macos still uses old version.

These changes lead to drop the test coverage (-0.6), so some works are done to make this coverage increase.

fix #391