### PR TITLE
Allow more "names" as vector components

### DIFF
--- a/mdal/frmts/mdal_gdal.cpp
+++ b/mdal/frmts/mdal_gdal.cpp
@@ -650,7 +650,7 @@ void MDAL::DriverGdal::parseBandIsVector( std::string &band_name, bool *is_vecto
        MDAL::contains( band_name, "u-component", MDAL::CaseInsensitive ) ||
        MDAL::contains( band_name, "u component", MDAL::CaseInsensitive ) ||
        MDAL::contains( band_name, "U wind component", MDAL::CaseInsensitive ) ||
-       MDAL::startsWith( band_name, "Northward", MDAL::CaseInsensitive ) ||
+       MDAL::contains( band_name, "eastward", MDAL::CaseInsensitive ) ||
        MDAL::contains( band_name, "x-component", MDAL::CaseInsensitive ) ||
        MDAL::contains( band_name, "x component", MDAL::CaseInsensitive ) )
   {
@@ -662,7 +662,7 @@ void MDAL::DriverGdal::parseBandIsVector( std::string &band_name, bool *is_vecto
             MDAL::contains( band_name, "v-component", MDAL::CaseInsensitive ) ||
             MDAL::contains( band_name, "v component", MDAL::CaseInsensitive ) ||
             MDAL::contains( band_name, "V wind component", MDAL::CaseInsensitive ) ||
-            MDAL::startsWith( band_name, "Eastward", MDAL::CaseInsensitive ) ||
+            MDAL::contains( band_name, "northward", MDAL::CaseInsensitive ) ||
             MDAL::contains( band_name, "y-component", MDAL::CaseInsensitive ) ||
             MDAL::contains( band_name, "y component", MDAL::CaseInsensitive ) )
   {
@@ -681,8 +681,8 @@ void MDAL::DriverGdal::parseBandIsVector( std::string &band_name, bool *is_vecto
     band_name = MDAL::replace( band_name, "v-component of", "", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "U wind component", "wind", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "V wind component", "wind", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "Northward", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "Eastward", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "eastward", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "northward", "", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "x-component of", "", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "y-component of", "", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "u-component", "", MDAL::CaseInsensitive );

--- a/mdal/frmts/mdal_gdal.cpp
+++ b/mdal/frmts/mdal_gdal.cpp
@@ -645,26 +645,28 @@ void MDAL::DriverGdal::parseBandIsVector( std::string &band_name, bool *is_vecto
 {
   band_name = MDAL::trim( band_name );
 
-  if ( MDAL::startsWith( band_name, "u-", MDAL::CaseInsensitive ) ||
-       MDAL::startsWith( band_name, "x-", MDAL::CaseInsensitive ) ||
+  if ( MDAL::contains( band_name, "U wind component", MDAL::CaseInsensitive ) ||
        MDAL::contains( band_name, "u-component", MDAL::CaseInsensitive ) ||
        MDAL::contains( band_name, "u component", MDAL::CaseInsensitive ) ||
-       MDAL::contains( band_name, "U wind component", MDAL::CaseInsensitive ) ||
-       MDAL::contains( band_name, "eastward", MDAL::CaseInsensitive ) ||
+       MDAL::startsWith( band_name, "u-", MDAL::CaseInsensitive ) ||
        MDAL::contains( band_name, "x-component", MDAL::CaseInsensitive ) ||
-       MDAL::contains( band_name, "x component", MDAL::CaseInsensitive ) )
+       MDAL::contains( band_name, "x component", MDAL::CaseInsensitive ) ||
+       MDAL::startsWith( band_name, "x-", MDAL::CaseInsensitive ) ||
+       MDAL::contains( band_name, "eastward", MDAL::CaseInsensitive ) ||
+       MDAL::contains( band_name, "zonal", MDAL::CaseInsensitive ) )
   {
     *is_vector = true; // vector
     *is_x =  true; //X-Axis
   }
-  else if ( MDAL::startsWith( band_name, "v-", MDAL::CaseInsensitive ) ||
-            MDAL::startsWith( band_name, "y-", MDAL::CaseInsensitive ) ||
+  else if ( MDAL::contains( band_name, "V wind component", MDAL::CaseInsensitive ) ||
             MDAL::contains( band_name, "v-component", MDAL::CaseInsensitive ) ||
             MDAL::contains( band_name, "v component", MDAL::CaseInsensitive ) ||
-            MDAL::contains( band_name, "V wind component", MDAL::CaseInsensitive ) ||
-            MDAL::contains( band_name, "northward", MDAL::CaseInsensitive ) ||
+            MDAL::startsWith( band_name, "v-", MDAL::CaseInsensitive ) ||
             MDAL::contains( band_name, "y-component", MDAL::CaseInsensitive ) ||
-            MDAL::contains( band_name, "y component", MDAL::CaseInsensitive ) )
+            MDAL::contains( band_name, "y component", MDAL::CaseInsensitive ) ||
+            MDAL::startsWith( band_name, "y-", MDAL::CaseInsensitive ) ||
+            MDAL::contains( band_name, "northward", MDAL::CaseInsensitive ) ||
+            MDAL::contains( band_name, "meridional", MDAL::CaseInsensitive ) )
   {
     *is_vector = true; // vector
     *is_x =  false; //Y-Axis
@@ -677,30 +679,48 @@ void MDAL::DriverGdal::parseBandIsVector( std::string &band_name, bool *is_vecto
 
   if ( *is_vector )
   {
-    band_name = MDAL::replace( band_name, "u-component of", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "v-component of", "", MDAL::CaseInsensitive );
+
     band_name = MDAL::replace( band_name, "U wind component", "wind", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "V wind component", "wind", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "eastward", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "northward", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "x-component of", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "y-component of", "", MDAL::CaseInsensitive );
+
+    band_name = MDAL::replace( band_name, "u-component of", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "v-component of", "", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "u-component", "", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "v-component", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "x-component", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "y-component", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "u component of", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "v component of", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "x component of", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "y component of", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "u component", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "v component", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "x component", "", MDAL::CaseInsensitive );
-    band_name = MDAL::replace( band_name, "y component", "", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "u-", "", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "v-", "", MDAL::CaseInsensitive );
+
+    band_name = MDAL::replace( band_name, "u component of", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "v component of", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "u component", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "v component", "", MDAL::CaseInsensitive );
+
+    band_name = MDAL::replace( band_name, "x-component of", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "y-component of", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "x-component", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "y-component", "", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "x-", "", MDAL::CaseInsensitive );
     band_name = MDAL::replace( band_name, "y-", "", MDAL::CaseInsensitive );
+
+    band_name = MDAL::replace( band_name, "x component of", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "y component of", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "x component", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "y component", "", MDAL::CaseInsensitive );
+
+    band_name = MDAL::replace( band_name, "eastward component of", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "northward component of", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "eastward component", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "northward component", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "eastward", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "northward", "", MDAL::CaseInsensitive );
+
+    band_name = MDAL::replace( band_name, "zonal component of", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "meridional component of", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "zonal component", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "meridional component", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "zonal", "", MDAL::CaseInsensitive );
+    band_name = MDAL::replace( band_name, "meridional", "", MDAL::CaseInsensitive );
+
     band_name = MDAL::trim( band_name );
   }
 }

--- a/mdal/frmts/mdal_ugrid.cpp
+++ b/mdal/frmts/mdal_ugrid.cpp
@@ -582,7 +582,8 @@ void MDAL::DriverUgrid::parseNetCDFVariableMetadata( int varid,
          MDAL::contains( longName, "zonal" ) )
     {
       *isVector = true;
-      name = MDAL::replace( longName, "x-component of", "" );
+      name = MDAL::replace( longName, ", x-component", "" );
+      name = MDAL::replace( name, "x-component of", "" );
       name = MDAL::replace( name, "x-component", "" );
       name = MDAL::replace( name, "x component of", "" );
       name = MDAL::replace( name, "x component", "" );
@@ -611,7 +612,8 @@ void MDAL::DriverUgrid::parseNetCDFVariableMetadata( int varid,
     {
       *isVector = true;
       *isX = false;
-      name = MDAL::replace( longName, "y-component of", "" );
+      name = MDAL::replace( longName, ", y-component", "" );
+      name = MDAL::replace( name, "y-component of", "" );
       name = MDAL::replace( name, "y-component", "" );
       name = MDAL::replace( name, "y component of", "" );
       name = MDAL::replace( name, "y component", "" );

--- a/mdal/frmts/mdal_ugrid.cpp
+++ b/mdal/frmts/mdal_ugrid.cpp
@@ -536,8 +536,8 @@ void MDAL::DriverUgrid::parseNetCDFVariableMetadata( int varid,
       {
         *isVector = true;
         name = MDAL::replace( standardName, "_x_", "" );
-        name = MDAL::replace( standardName, "_eastward_", "" );
-        name = MDAL::replace( standardName, "eastward_", "" );
+        name = MDAL::replace( name, "_eastward_", "" );
+        name = MDAL::replace( name, "eastward_", "" );
       }
       else if ( MDAL::contains( standardName, "_y_" ) ||
                 MDAL::contains( standardName, "northward_" ) )
@@ -545,8 +545,8 @@ void MDAL::DriverUgrid::parseNetCDFVariableMetadata( int varid,
         *isVector = true;
         *isX = false;
         name = MDAL::replace( standardName, "_y_", "" );
-        name = MDAL::replace( standardName, "_northward_", "" );
-        name = MDAL::replace( standardName, "northward_", "" );
+        name = MDAL::replace( name, "_northward_", "" );
+        name = MDAL::replace( name, "northward_", "" );
       }
       else if ( MDAL::contains( standardName, "_from_direction" ) )
       {
@@ -574,18 +574,62 @@ void MDAL::DriverUgrid::parseNetCDFVariableMetadata( int varid,
   else
   {
     variableName = longName;
-    if ( MDAL::contains( longName, ", x-component" ) || MDAL::contains( longName, "u component of " ) )
+    if ( MDAL::contains( longName, "x-component" ) ||
+         MDAL::contains( longName, "x component" ) ||
+         MDAL::contains( longName, "u-component" ) ||
+         MDAL::contains( longName, "u component" ) ||
+         MDAL::contains( longName, "eastward" ) ||
+         MDAL::contains( longName, "zonal" ) )
     {
       *isVector = true;
-      name = MDAL::replace( longName, ", x-component", "" );
-      name = MDAL::replace( name, "u component of ", "" );
+      name = MDAL::replace( longName, "x-component of", "" );
+      name = MDAL::replace( name, "x-component", "" );
+      name = MDAL::replace( name, "x component of", "" );
+      name = MDAL::replace( name, "x component", "" );
+
+      name = MDAL::replace( name, "u-component of", "" );
+      name = MDAL::replace( name, "u-component", "" );
+      name = MDAL::replace( name, "u component of", "" );
+      name = MDAL::replace( name, "u component", "" );
+
+      name = MDAL::replace( name, "eastward component of", "" );
+      name = MDAL::replace( name, "eastward component", "" );
+      name = MDAL::replace( name, "eastward", "" );
+
+      name = MDAL::replace( name, "zonal component of", "" );
+      name = MDAL::replace( name, "zonal component", "" );
+      name = MDAL::replace( name, "zonal", "" );
+
+      name = MDAL::trim( name );
     }
-    else if ( MDAL::contains( longName, ", y-component" ) || MDAL::contains( longName, "v component of " ) )
+    else if ( MDAL::contains( longName, "y-component" ) ||
+              MDAL::contains( longName, "y component" ) ||
+              MDAL::contains( longName, "v-component" ) ||
+              MDAL::contains( longName, "v component" ) ||
+              MDAL::contains( longName, "northward" ) ||
+              MDAL::contains( longName, "meridional" ) )
     {
       *isVector = true;
       *isX = false;
-      name = MDAL::replace( longName, ", y-component", "" );
-      name = MDAL::replace( name, "v component of ", "" );
+      name = MDAL::replace( longName, "y-component of", "" );
+      name = MDAL::replace( name, "y-component", "" );
+      name = MDAL::replace( name, "y component of", "" );
+      name = MDAL::replace( name, "y component", "" );
+
+      name = MDAL::replace( name, "v-component of", "" );
+      name = MDAL::replace( name, "v-component", "" );
+      name = MDAL::replace( name, "v component of", "" );
+      name = MDAL::replace( name, "v component", "" );
+
+      name = MDAL::replace( name, "northward component of", "" );
+      name = MDAL::replace( name, "northward component", "" );
+      name = MDAL::replace( name, "northward", "" );
+
+      name = MDAL::replace( name, "meridional component of", "" );
+      name = MDAL::replace( name, "meridional component", "" );
+      name = MDAL::replace( name, "meridional", "" );
+
+      name = MDAL::trim( name );
     }
     else if ( MDAL::contains( longName, " magnitude" ) )
     {

--- a/mdal/frmts/mdal_ugrid.cpp
+++ b/mdal/frmts/mdal_ugrid.cpp
@@ -531,16 +531,22 @@ void MDAL::DriverUgrid::parseNetCDFVariableMetadata( int varid,
     else
     {
       variableName = standardName;
-      if ( MDAL::contains( standardName, "_x_" ) )
+      if ( MDAL::contains( standardName, "_x_" ) ||
+           MDAL::contains( standardName, "eastward_" ) )
       {
         *isVector = true;
         name = MDAL::replace( standardName, "_x_", "" );
+        name = MDAL::replace( standardName, "_eastward_", "" );
+        name = MDAL::replace( standardName, "eastward_", "" );
       }
-      else if ( MDAL::contains( standardName, "_y_" ) )
+      else if ( MDAL::contains( standardName, "_y_" ) ||
+                MDAL::contains( standardName, "northward_" ) )
       {
         *isVector = true;
         *isX = false;
         name = MDAL::replace( standardName, "_y_", "" );
+        name = MDAL::replace( standardName, "_northward_", "" );
+        name = MDAL::replace( standardName, "northward_", "" );
       }
       else if ( MDAL::contains( standardName, "_from_direction" ) )
       {

--- a/tests/test_gdal_netcdf.cpp
+++ b/tests/test_gdal_netcdf.cpp
@@ -60,7 +60,7 @@ TEST( MeshGdalNetCDFTest, OceanCurrents )
   int count = MDAL_D_valueCount( ds );
   ASSERT_EQ( 43621, count );
 
-  double value = getValueX( ds, 144 );
+  double value = getValueY( ds, 144 );
   EXPECT_DOUBLE_EQ( -0.4306640625, value );
 
   double min, max;


### PR DESCRIPTION
Hello, this PR fix the switched eastward/northward variables in `mdal/frmts/mdal_gdal.cpp`, as discussed in #444 .
Allow more variables names to be recognized as valid vector components, e.g.:
U/X components: eastward and zonal
V/Y components:  northward and meridional

A better way would be to use regex to check valid variables names (e.g.: (x|u|eastward|zonal)) to allow for the multitude of possible long names, e.g.:

* eastward wind
* zonal wind component
* zonal component of wind
* u-wind
* x-component of wind
* ...

and [standard names](https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html), e.g.:

* eastward_wind
* geostrophic_eastward_wind
* x_wind
* ...

but unfortunately I am not proficient in C++.

Thank you.
