### PR TITLE
Fix mixup between <cstdint> and <stdint.h> in libplyxx

### DIFF
--- a/mdal/3rdparty/libplyxx/libplyxx_internal.h
+++ b/mdal/3rdparty/libplyxx/libplyxx_internal.h
@@ -115,8 +115,8 @@ namespace libply
     t.quad = 1;
     if (t.islittle ^ endian) return w;
 
-    auto ptr = reinterpret_cast<std::uint8_t*>(&w);
-    std::array<std::uint8_t, sizeof(T)> raw_src, raw_dst;
+    auto ptr = reinterpret_cast<uint8_t*>(&w);
+    std::array<uint8_t, sizeof(T)> raw_src, raw_dst;
 
     for(std::size_t i = 0; i < sizeof(T); ++i)
         raw_src[i] = ptr[i];


### PR DESCRIPTION
I was unable to build mdal using GCC 13.1.1 due to the following error:
```
.../mdal/mdal/3rdparty/libplyxx/libplyxx_internal.h: In function ‘T libply::endian_convert(T, uint32_t)’:
.../mdal/mdal/3rdparty/libplyxx/libplyxx_internal.h:118:38: error: ‘uint8_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
  118 |     auto ptr = reinterpret_cast<std::uint8_t*>(&w);
      |                                      ^~~~~~~
      |                                      wint_t

```

I see that https://github.com/lutraconsulting/MDAL/pull/453 introduced the usage of `std::uint8_t` (as if the header file includes `<cstdint>`), while the remainder of the header file uses integer types from the global namespace.

I am quite new to this codebase, so please tell me if I am missing some context.