### PR TITLE
Fix: Bad bytes in header record

### DIFF
--- a/mdal/frmts/mdal_selafin.cpp
+++ b/mdal/frmts/mdal_selafin.cpp
@@ -982,7 +982,7 @@ void MDAL::DriverSelafin::save( const std::string &fileName, const std::string &
   std::ofstream file = MDAL::openOutputFile( fileName.c_str(), std::ofstream::binary );
 
   std::string header( "Selafin file created by MDAL library" );
-  std::string remainingStr( " ", 72 - header.size() );
+  std::string remainingStr( 72 - header.size(), ' ' );
   header.append( remainingStr );
   header.append( "SERAFIND" );
   assert( header.size() == 80 );


### PR DESCRIPTION
Fixes issue #479

The correct std::string constructor is now called.