### PR TITLE
Fix selafin special characters

### DIFF
--- a/mdal/frmts/mdal_selafin.cpp
+++ b/mdal/frmts/mdal_selafin.cpp
@@ -1290,9 +1290,9 @@ bool MDAL::SelafinFile::addDatasetGroup( MDAL::DatasetGroup *datasetGroup )
   if ( datasetGroup->uri() == mFileName )
     datasetGroup->mesh()->closeSource();
 
-  if ( !MDAL::deleteFile(mFileName) || !MDAL::renameFile(tempFileName, mFileName) )
+  if ( !MDAL::deleteFile( mFileName ) || !MDAL::renameFile( tempFileName, mFileName ) )
   {
-    MDAL::deleteFile(tempFileName);
+    MDAL::deleteFile( tempFileName );
     throw MDAL::Error( MDAL_Status::Err_FailToWriteToDisk, "Unable to write dataset in file" );
   }
 

--- a/mdal/frmts/mdal_selafin.cpp
+++ b/mdal/frmts/mdal_selafin.cpp
@@ -1290,13 +1290,11 @@ bool MDAL::SelafinFile::addDatasetGroup( MDAL::DatasetGroup *datasetGroup )
   if ( datasetGroup->uri() == mFileName )
     datasetGroup->mesh()->closeSource();
 
-  if ( std::remove( mFileName.c_str() ) != 0 )
+  if ( !MDAL::deleteFile(mFileName) || !MDAL::renameFile(tempFileName, mFileName) )
   {
-    std::remove( tempFileName.c_str() );
+    MDAL::deleteFile(tempFileName);
     throw MDAL::Error( MDAL_Status::Err_FailToWriteToDisk, "Unable to write dataset in file" );
   }
-
-  std::rename( tempFileName.c_str(), mFileName.c_str() );
 
   parseFile();
 

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -111,7 +111,7 @@ bool MDAL::deleteFile( const std::string &path )
     std::wstring wStr = converter.from_bytes( path );
     return DeleteFileW( wStr.c_str() ) != 0;
 #else
-    return remove( path.c_str() ) == 0;
+    return std::remove( path.c_str() ) == 0;
 #endif
   }
 

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -102,31 +102,31 @@ std::string MDAL::readFileToString( const std::string &filename )
   return "";
 }
 
-bool MDAL::deleteFile(const std::string& path)
+bool MDAL::deleteFile( const std::string &path )
 {
-    if (MDAL::fileExists(path))
-    {
-#ifdef _MSC_VER
-      std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
-      std::wstring wStr = converter.from_bytes(path);
-      return DeleteFileW(wStr.c_str()) != 0;
-#else
-      return remove(path.c_str()) == 0;
-#endif
-    }
-
-    return false;
-}
-
-bool MDAL::renameFile(const std::string& from, const std::string& to)
-{
+  if ( MDAL::fileExists( path ) )
+  {
 #ifdef _MSC_VER
     std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
-    std::wstring wFrom = converter.from_bytes(from);
-    std::wstring wTo = converter.from_bytes(to);
-    return _wrename(wFrom.c_str(), wTo.c_str()) == 0;
+    std::wstring wStr = converter.from_bytes( path );
+    return DeleteFileW( wStr.c_str() ) != 0;
 #else
-    return std::rename(from.c_str(), to.c_str()) == 0;
+    return remove( path.c_str() ) == 0;
+#endif
+  }
+
+  return false;
+}
+
+bool MDAL::renameFile( const std::string &from, const std::string &to )
+{
+#ifdef _MSC_VER
+  std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
+  std::wstring wFrom = converter.from_bytes( from );
+  std::wstring wTo = converter.from_bytes( to );
+  return _wrename( wFrom.c_str(), wTo.c_str() ) == 0;
+#else
+  return std::rename( from.c_str(), to.c_str() ) == 0;
 #endif
 }
 

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -102,6 +102,34 @@ std::string MDAL::readFileToString( const std::string &filename )
   return "";
 }
 
+bool MDAL::deleteFile(const std::string& path)
+{
+    if (MDAL::fileExists(path))
+    {
+#ifdef _MSC_VER
+      std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
+      std::wstring wStr = converter.from_bytes(path);
+      return DeleteFileW(wStr.c_str()) != 0;
+#else
+      return remove(path.c_str()) == 0;
+#endif
+    }
+
+    return false;
+}
+
+bool MDAL::renameFile(const std::string& from, const std::string& to)
+{
+#ifdef _MSC_VER
+    std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
+    std::wstring wFrom = converter.from_bytes(from);
+    std::wstring wTo = converter.from_bytes(to);
+    return _wrename(wFrom.c_str(), wTo.c_str()) == 0;
+#else
+    return std::rename(from.c_str(), to.c_str()) == 0;
+#endif
+}
+
 bool MDAL::startsWith( const std::string &str, const std::string &substr, ContainsBehaviour behaviour )
 {
   if ( ( str.size() < substr.size() ) || substr.empty() )

--- a/mdal/mdal_utils.hpp
+++ b/mdal/mdal_utils.hpp
@@ -74,7 +74,7 @@ namespace MDAL
   //! Deletes a file. Returns true on success, false otherwise
   bool deleteFile( const std::string &path );
 
-  //!renames a file. Returns true on success, false otherwise
+  //! Renames a file. Returns true on success, false otherwise
   bool renameFile( const std::string &from, const std::string &to );
 
   // strings

--- a/mdal/mdal_utils.hpp
+++ b/mdal/mdal_utils.hpp
@@ -72,10 +72,10 @@ namespace MDAL
   std::string readFileToString( const std::string &filename );
 
   //! Deletes a file. Returns true on success, false otherwise
-  bool deleteFile(const std::string& path);
+  bool deleteFile( const std::string &path );
 
   //!renames a file. Returns true on success, false otherwise
-  bool renameFile(const std::string& from, const std::string& to);
+  bool renameFile( const std::string &from, const std::string &to );
 
   // strings
   enum ContainsBehaviour

--- a/mdal/mdal_utils.hpp
+++ b/mdal/mdal_utils.hpp
@@ -71,6 +71,12 @@ namespace MDAL
   std::string pathJoin( const std::string &path1, const std::string &path2 );
   std::string readFileToString( const std::string &filename );
 
+  //! Deletes a file. Returns true on success, false otherwise
+  bool deleteFile(const std::string& path);
+
+  //!renames a file. Returns true on success, false otherwise
+  bool renameFile(const std::string& from, const std::string& to);
+
   // strings
   enum ContainsBehaviour
   {

--- a/tests/mdal_testutils.cpp
+++ b/tests/mdal_testutils.cpp
@@ -14,6 +14,12 @@
 #include <fstream>
 #include <stdio.h>
 
+#ifdef _MSC_VER
+#include <locale>
+#include <codecvt>
+#include <stringapiset.h>
+#endif
+
 const char *data_path()
 {
   return TESTDATA;
@@ -52,13 +58,31 @@ void copy( const std::string &src, const std::string &dest )
 void deleteFile( const std::string &path )
 {
   if ( fileExists( path ) )
+  {
+#ifdef _MSC_VER
+    std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
+    std::wstring wStr = converter.from_bytes(path);
+    DeleteFileW(wStr.c_str());
+#else
     remove( path.c_str() );
+#endif
+  }
 }
 
 bool fileExists( const std::string &filename )
 {
-  std::ifstream in( filename );
-  return in.good();
+#ifdef _MSC_VER
+    std::ifstream in;
+    std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
+    std::wstring wStr = converter.from_bytes(filename);
+    in.open(wStr, std::ifstream::in | std::ifstream::binary);
+    if (!in.is_open())
+        return false;
+#else
+    std::ifstream in(filename);
+#endif
+
+    return in.good();
 }
 
 int getActive( MDAL_DatasetH dataset, int index )

--- a/tests/mdal_testutils.cpp
+++ b/tests/mdal_testutils.cpp
@@ -61,8 +61,8 @@ void deleteFile( const std::string &path )
   {
 #ifdef _MSC_VER
     std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
-    std::wstring wStr = converter.from_bytes(path);
-    DeleteFileW(wStr.c_str());
+    std::wstring wStr = converter.from_bytes( path );
+    DeleteFileW( wStr.c_str() );
 #else
     remove( path.c_str() );
 #endif
@@ -72,17 +72,17 @@ void deleteFile( const std::string &path )
 bool fileExists( const std::string &filename )
 {
 #ifdef _MSC_VER
-    std::ifstream in;
-    std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
-    std::wstring wStr = converter.from_bytes(filename);
-    in.open(wStr, std::ifstream::in | std::ifstream::binary);
-    if (!in.is_open())
-        return false;
+  std::ifstream in;
+  std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > converter;
+  std::wstring wStr = converter.from_bytes( filename );
+  in.open( wStr, std::ifstream::in | std::ifstream::binary );
+  if ( !in.is_open() )
+    return false;
 #else
-    std::ifstream in(filename);
+  std::ifstream in( filename );
 #endif
 
-    return in.good();
+  return in.good();
 }
 
 int getActive( MDAL_DatasetH dataset, int index )

--- a/tests/test_selafin.cpp
+++ b/tests/test_selafin.cpp
@@ -429,43 +429,43 @@ TEST( MeshSLFTest, WriteDatasetInNewFile )
   MDAL_CloseMesh( newMesh );
 }
 
-TEST(MeshSLFTest, WriteDatasetSpecialCharacters)
+TEST( MeshSLFTest, WriteDatasetSpecialCharacters )
 {
-    std::string path = test_file("/slf/example_res_fr.slf");
-    EXPECT_EQ(MDAL_MeshNames(path.c_str()), "SELAFIN:\"" + path + "\"");
-    MDAL_MeshH m = MDAL_LoadMesh(path.c_str());
-    ASSERT_NE(m, nullptr);
+  std::string path = test_file( "/slf/example_res_fr.slf" );
+  EXPECT_EQ( MDAL_MeshNames( path.c_str() ), "SELAFIN:\"" + path + "\"" );
+  MDAL_MeshH m = MDAL_LoadMesh( path.c_str() );
+  ASSERT_NE( m, nullptr );
 
-    MDAL_DriverH driver = MDAL_driverFromName("SELAFIN");
-    ASSERT_NE(driver, nullptr);
+  MDAL_DriverH driver = MDAL_driverFromName( "SELAFIN" );
+  ASSERT_NE( driver, nullptr );
 
-    //Add dataset
+  //Add dataset
 #ifdef _MSC_VER
-    std::wstring wFileName = std::wstring(L"/selafin_äöüß.slf");
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    std::string fileName = converter.to_bytes(wFileName);
+  std::wstring wFileName = std::wstring( L"/selafin_Ã¤Ã¶Ã¼ÃŸ.slf" );
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+  std::string fileName = converter.to_bytes( wFileName );
 #else
-    std::string fileName = "/selafin_äöüß.slf";
+  std::string fileName = "/selafin_Ã¤Ã¶Ã¼ÃŸ.slf";
 #endif
-    std::string file = tmp_file(fileName);
-    deleteFile(file);
+  std::string file = tmp_file( fileName );
+  deleteFile( file );
 
-    addNewScalarDatasetGroup(m, driver, file);
-    addNewVectorDatasetGroup(m, driver, file);
-    MDAL_CloseMesh(m);
+  addNewScalarDatasetGroup( m, driver, file );
+  addNewVectorDatasetGroup( m, driver, file );
+  MDAL_CloseMesh( m );
 
-    MDAL_MeshH newMesh = MDAL_LoadMesh(file.c_str());
-    ASSERT_NE(newMesh, nullptr);
+  MDAL_MeshH newMesh = MDAL_LoadMesh( file.c_str() );
+  ASSERT_NE( newMesh, nullptr );
 
-    EXPECT_EQ(2, MDAL_M_datasetGroupCount(newMesh));
+  EXPECT_EQ( 2, MDAL_M_datasetGroupCount( newMesh ) );
 
-    // Scalar dataset group added
-    testScalarDatasetGroupAdded(MDAL_M_datasetGroup(newMesh, 0));
+  // Scalar dataset group added
+  testScalarDatasetGroupAdded( MDAL_M_datasetGroup( newMesh, 0 ) );
 
-    // Vector dataset group added
-    testVectorDatasetGroupAdded(MDAL_M_datasetGroup(newMesh, 1));
+  // Vector dataset group added
+  testVectorDatasetGroupAdded( MDAL_M_datasetGroup( newMesh, 1 ) );
 
-    MDAL_CloseMesh(newMesh);
+  MDAL_CloseMesh( newMesh );
 }
 
 TEST( MeshSLFTest, loadDatasetFromFile )

--- a/tests/test_selafin.cpp
+++ b/tests/test_selafin.cpp
@@ -441,7 +441,7 @@ TEST( MeshSLFTest, WriteDatasetSpecialCharacters )
 
   //Add dataset
 #ifdef _MSC_VER
-  std::wstring wFileName = std::wstring( L"/selafin_äöüß.slf" );
+  std::wstring wFileName = std::wstring( L"/selafin_\u00E4\u00F6\u00FC\u00DF.slf" );
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   std::string fileName = converter.to_bytes( wFileName );
 #else


### PR DESCRIPTION
Fixes #483

First off, a regression test (WriteDatasetSpecialCharacters) was written so that the issue at hand could be reproduced.
Then the issue was fixed. Some instances of std::string had to be converted to std::wstring followed by windows-specific system calls.
The solution is analogous to the way cross-platform strings are currently handled in mdal_utils.h/.cpp.