### PR TITLE
handle metadata in mike21 format

### DIFF
--- a/.github/workflows/osx_tests.yml
+++ b/.github/workflows/osx_tests.yml
@@ -4,7 +4,7 @@ env:
   QGIS_DEPS_VERSION: 0.4.0
 jobs:
   osx_tests:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Checkout MDAL
         uses: actions/checkout@v2

--- a/docs/.azure-pipelines.yml
+++ b/docs/.azure-pipelines.yml
@@ -20,7 +20,7 @@ variables:
 jobs:
   - job: 'Documentation'
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-latest'
     container:
       image: osgeo/proj-docs
       options: --privileged

--- a/docs/.azure-pipelines.yml
+++ b/docs/.azure-pipelines.yml
@@ -20,7 +20,7 @@ variables:
 jobs:
   - job: 'Documentation'
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'ubuntu-16.04'
     container:
       image: osgeo/proj-docs
       options: --privileged

--- a/docs/source/drivers/index.rst
+++ b/docs/source/drivers/index.rst
@@ -40,3 +40,4 @@ MDAL drivers
    dfsu
    dfs2
    h2i
+   mike21

--- a/mdal/frmts/mdal_mike21.hpp
+++ b/mdal/frmts/mdal_mike21.hpp
@@ -88,6 +88,10 @@ namespace MDAL
 
     private:
       std::string mMeshFile;
+      std::string mCrs;
+      std::string mDataType;
+      std::string mDataUnit;
+      size_t mVertexCount = 0;
       // regex for header line in form of - integer string
       const std::regex mRegexHeader2011 = std::regex( "(\\d+)\\s+(.+)(\\s+)?" );
       // regex for header line in form of - integer integer integer string
@@ -96,8 +100,7 @@ namespace MDAL
       const std::regex mRegexElementHeader = std::regex( "(\\d+)\\s+(\\d)\\s+(\\d{2})(\\s+)?" );
 
       bool canReadHeader( const std::string &line );
-      size_t getVertexCount( const std::string &line );
-      std::string getCrs( const std::string &line );
+      void parseHeader( const std::string &line );
   };
 
 } // namespace MDAL

--- a/tests/mdal_testutils.cpp
+++ b/tests/mdal_testutils.cpp
@@ -255,6 +255,31 @@ void compareMeshFrames( MDAL_MeshH meshA, MDAL_MeshH meshB )
   EXPECT_TRUE( compareVectors( verticesA, verticesB ) );
 }
 
+void compareMeshMetadata( MDAL_MeshH meshA, MDAL_MeshH meshB )
+{
+  // Metadata count
+  const int orignal_m_count = MDAL_M_metadataCount( meshA );
+  const int saved_m_count = MDAL_M_metadataCount( meshB );
+  EXPECT_EQ( orignal_m_count, saved_m_count );
+
+  // Metadata values
+  for ( int i = 0; i < orignal_m_count; ++i )
+  {
+    const std::string keyA( MDAL_M_metadataKey( meshA, i ) );
+    const std::string valA( MDAL_M_metadataValue( meshA, i ) );
+    for ( int j = 0; j < saved_m_count; ++j )
+    {
+      const std::string keyB( MDAL_M_metadataKey( meshB, j ) );
+      const std::string valB( MDAL_M_metadataValue( meshB, j ) );
+
+      if ( keyA == keyB && valA == valB )
+        break;
+      else if ( j == saved_m_count - 1 )
+        FAIL() << "Mesh metadata do not match: " << keyA << ": " << valA;
+    }
+  }
+}
+
 std::vector<double> getCoordinates( MDAL_MeshH mesh, int verticesCount )
 {
   MDAL_MeshVertexIteratorH iterator = MDAL_M_vertexIterator( mesh );
@@ -399,7 +424,7 @@ bool compareReferenceTime( MDAL_DatasetGroupH group, const char *referenceTime )
   return std::strcmp( MDAL_G_referenceTime( group ), referenceTime ) == 0;
 }
 
-void saveAndCompareMesh( const std::string &filename, const std::string &savedFile, const std::string &driver, const std::string &meshName )
+void saveAndCompareMesh( const std::string &filename, const std::string &savedFile, const std::string &driver, const std::string &meshName, bool compareMetadata )
 {
   //test driver capability
   EXPECT_TRUE( MDAL_DR_saveMeshCapability( MDAL_driverFromName( driver.c_str() ) ) );
@@ -433,6 +458,8 @@ void saveAndCompareMesh( const std::string &filename, const std::string &savedFi
 
   // Compare saved with the original mesh
   compareMeshFrames( meshToSave, savedMesh );
+  if ( compareMetadata )
+    compareMeshMetadata( meshToSave, savedMesh );
 
   MDAL_CloseMesh( savedMesh );
 

--- a/tests/mdal_testutils.hpp
+++ b/tests/mdal_testutils.hpp
@@ -62,7 +62,8 @@ bool compareVectors( const std::vector<int> &a, const std::vector<int> &b );
 
 //! Same vertices (coords), faces, edges and connectivity between them
 void compareMeshFrames( MDAL_MeshH meshA, MDAL_MeshH meshB );
-void saveAndCompareMesh( const std::string &filename, const std::string &savedFile, const std::string &driver, const std::string &meshName = "" );
+void compareMeshMetadata( MDAL_MeshH meshA, MDAL_MeshH meshB );
+void saveAndCompareMesh( const std::string &filename, const std::string &savedFile, const std::string &driver, const std::string &meshName = "", bool compareMetadata = false );
 
 //! Compare duration with millisecond precision
 bool compareDurationInHours( double h1, double h2 );

--- a/tests/test_mike21.cpp
+++ b/tests/test_mike21.cpp
@@ -191,15 +191,27 @@ TEST( MeshMike21Test, ReadOdenseRough )
 TEST( MeshMike21Test, SaveMike21MeshToFile )
 {
   saveAndCompareMesh(
+    test_file( "/mike21/small.mesh" ),
+    tmp_file( "/small_saved.mesh" ),
+    "Mike21",
+    "",
+    true
+  );
+
+  saveAndCompareMesh(
     test_file( "/mike21/odense_rough_comparison.mesh" ),
     tmp_file( "/odense_rough_saved.mesh" ),
-    "Mike21"
+    "Mike21",
+    "",
+    true
   );
 
   saveAndCompareMesh(
     test_file( "/mike21/odense_rough_quads_comparion.mesh" ),
     tmp_file( "/odense_rough_quads_saved.mesh" ),
-    "Mike21"
+    "Mike21",
+    "",
+    true
   );
 }
 


### PR DESCRIPTION
Handle type, unit of the bathymetry data and crs of Mike21 format as Mesh metadata so it can be preserved when saving.