### PR TITLE
Unique DatasetGroup for Mesh 

### DIFF
--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -377,6 +377,14 @@ MDAL_EXPORT int MDAL_M_faceVerticesMaximumCount( MDAL_MeshH mesh );
 MDAL_EXPORT void MDAL_M_LoadDatasets( MDAL_MeshH mesh, const char *datasetFile );
 
 /**
+ * Removes DatasetGroup from Mesh based on it's name. On error see MDAL_LastStatus 
+ * for error type.
+ * 
+ * \since MDAL 1.3.0
+ */
+MDAL_EXPORT void MDAL_M_RemoveDatasetGroup( MDAL_MeshH mesh, const char *datasetGroupName);
+
+/**
  * Returns number of metadata values
  *
  * \since MDAL 0.9.0

--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -377,12 +377,12 @@ MDAL_EXPORT int MDAL_M_faceVerticesMaximumCount( MDAL_MeshH mesh );
 MDAL_EXPORT void MDAL_M_LoadDatasets( MDAL_MeshH mesh, const char *datasetFile );
 
 /**
- * Removes DatasetGroup from Mesh based on it's name. On error see MDAL_LastStatus 
+ * Removes DatasetGroup from Mesh based on it's name. On error see MDAL_LastStatus
  * for error type.
- * 
+ *
  * \since MDAL 1.3.0
  */
-MDAL_EXPORT void MDAL_M_RemoveDatasetGroup( MDAL_MeshH mesh, const char *datasetGroupName);
+MDAL_EXPORT void MDAL_M_RemoveDatasetGroup( MDAL_MeshH mesh, const char *datasetGroupName );
 
 /**
  * Returns number of metadata values

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <assert.h>
 #include <memory>
+#include <map>
 
 #include "mdal.h"
 #include "mdal_driver_manager.hpp"
@@ -412,6 +413,41 @@ void MDAL_M_LoadDatasets( MDAL_MeshH mesh, const char *datasetFile )
 
   std::string filename( datasetFile );
   MDAL::DriverManager::instance().loadDatasets( m, datasetFile );
+}
+void MDAL_M_RemoveDatasetGroup( MDAL_MeshH mesh, const char *datasetGroupName)
+{
+  if ( !mesh )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, "Mesh is not valid (null)" );
+    return;
+  }
+
+  if ( !datasetGroupName )
+  {
+    MDAL::Log::error( MDAL_Status::Err_InvalidData, "Dataset name is not valid (null)" );
+    return;
+  }
+
+  MDAL::Mesh *m = static_cast< MDAL::Mesh * >( mesh );
+  
+  std::map<std::string, int> datasetNames;
+  for (long unsigned int i = 0; i < m->datasetGroups.size(); ++i)
+  {
+    std::shared_ptr<MDAL::DatasetGroup> datasetGroup = m->datasetGroups[i];
+    datasetNames.insert({datasetGroup->name(), i});
+  }
+  
+  auto it = datasetNames.find(datasetGroupName); 
+  if (it == datasetNames.end())
+  {
+    MDAL::Log::error( MDAL_Status::Err_InvalidData, "Dataset name is not found in the mesh" );
+    return;
+  }
+  else
+  {
+    m->datasetGroups.erase(m->datasetGroups.begin() + it->second);
+    MDAL::Log::info("Dataset " + std::string(datasetGroupName) + " removed from the mesh");
+  }
 }
 
 int MDAL_M_metadataCount( MDAL_MeshH mesh )

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -414,7 +414,8 @@ void MDAL_M_LoadDatasets( MDAL_MeshH mesh, const char *datasetFile )
   std::string filename( datasetFile );
   MDAL::DriverManager::instance().loadDatasets( m, datasetFile );
 }
-void MDAL_M_RemoveDatasetGroup( MDAL_MeshH mesh, const char *datasetGroupName)
+
+void MDAL_M_RemoveDatasetGroup( MDAL_MeshH mesh, const char *datasetGroupName )
 {
   if ( !mesh )
   {
@@ -429,24 +430,24 @@ void MDAL_M_RemoveDatasetGroup( MDAL_MeshH mesh, const char *datasetGroupName)
   }
 
   MDAL::Mesh *m = static_cast< MDAL::Mesh * >( mesh );
-  
+
   std::map<std::string, int> datasetNames;
-  for (long unsigned int i = 0; i < m->datasetGroups.size(); ++i)
+  for ( long unsigned int i = 0; i < m->datasetGroups.size(); ++i )
   {
     std::shared_ptr<MDAL::DatasetGroup> datasetGroup = m->datasetGroups[i];
-    datasetNames.insert({datasetGroup->name(), i});
+    datasetNames.insert( {datasetGroup->name(), i} );
   }
-  
-  auto it = datasetNames.find(datasetGroupName); 
-  if (it == datasetNames.end())
+
+  auto it = datasetNames.find( datasetGroupName );
+  if ( it == datasetNames.end() )
   {
     MDAL::Log::error( MDAL_Status::Err_InvalidData, "Dataset name is not found in the mesh" );
     return;
   }
   else
   {
-    m->datasetGroups.erase(m->datasetGroups.begin() + it->second);
-    MDAL::Log::info("Dataset " + std::string(datasetGroupName) + " removed from the mesh");
+    m->datasetGroups.erase( m->datasetGroups.begin() + it->second );
+    MDAL::Log::info( "Dataset " + std::string( datasetGroupName ) + " removed from the mesh" );
   }
 }
 

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -417,6 +417,8 @@ void MDAL_M_LoadDatasets( MDAL_MeshH mesh, const char *datasetFile )
 
 void MDAL_M_RemoveDatasetGroup( MDAL_MeshH mesh, const char *datasetGroupName )
 {
+  MDAL::Log::resetLastStatus();
+
   if ( !mesh )
   {
     MDAL::Log::error( MDAL_Status::Err_IncompatibleMesh, "Mesh is not valid (null)" );

--- a/mdal/mdal_data_model.cpp
+++ b/mdal/mdal_data_model.cpp
@@ -7,6 +7,8 @@
 #include <assert.h>
 #include <math.h>
 #include <algorithm>
+#include <regex>
+#include <set>
 #include "mdal_utils.hpp"
 
 MDAL::Dataset::~Dataset() = default;
@@ -205,7 +207,33 @@ std::string MDAL::DatasetGroup::name()
 
 void MDAL::DatasetGroup::setName( const std::string &name )
 {
-  setMetadata( "name", name );
+  std::string assignedName = name;
+  std::set<std::string> existingNames;
+
+  for ( std::shared_ptr<MDAL::DatasetGroup> existingGroup : mParent->datasetGroups )
+  {
+    existingNames.insert( existingGroup->name() );
+  }
+
+  while ( existingNames.find( assignedName ) != existingNames.end() )
+  {
+      std::regex reEndsNumber( "_[0-9]+$" );
+      std::regex reNumber( "[0-9]+$" );
+      std::smatch m;
+      if ( std::regex_search( assignedName, reEndsNumber ) )
+      {
+        if ( std::regex_search( assignedName, m, reNumber ))
+        {
+          int number = std::stoi( m.str() );
+          assignedName = assignedName.substr( 0, assignedName.size() - m.str().size() ) + std::to_string( number + 1 );
+        }    
+      }
+      else{
+        assignedName = assignedName + "_1"; 
+      }
+  }
+
+  setMetadata( "name", assignedName );
 }
 
 std::string MDAL::DatasetGroup::uri() const

--- a/mdal/mdal_data_model.cpp
+++ b/mdal/mdal_data_model.cpp
@@ -217,20 +217,21 @@ void MDAL::DatasetGroup::setName( const std::string &name )
 
   while ( existingNames.find( assignedName ) != existingNames.end() )
   {
-      std::regex reEndsNumber( "_[0-9]+$" );
-      std::regex reNumber( "[0-9]+$" );
-      std::smatch m;
-      if ( std::regex_search( assignedName, reEndsNumber ) )
+    std::regex reEndsNumber( "_[0-9]+$" );
+    std::regex reNumber( "[0-9]+$" );
+    std::smatch m;
+    if ( std::regex_search( assignedName, reEndsNumber ) )
+    {
+      if ( std::regex_search( assignedName, m, reNumber ) )
       {
-        if ( std::regex_search( assignedName, m, reNumber ))
-        {
-          int number = std::stoi( m.str() );
-          assignedName = assignedName.substr( 0, assignedName.size() - m.str().size() ) + std::to_string( number + 1 );
-        }    
+        int number = std::stoi( m.str() );
+        assignedName = assignedName.substr( 0, assignedName.size() - m.str().size() ) + std::to_string( number + 1 );
       }
-      else{
-        assignedName = assignedName + "_1"; 
-      }
+    }
+    else
+    {
+      assignedName = assignedName + "_1";
+    }
   }
 
   setMetadata( "name", assignedName );

--- a/tests/test_api.cpp
+++ b/tests/test_api.cpp
@@ -676,6 +676,55 @@ TEST( ApiTest, DuplicatedDatasetNames )
   ASSERT_EQ( 5, names.size() );
 }
 
+TEST( ApiTest, DatasetRemoval )
+{
+  MDAL_SetLoggerCallback( &_testLoggerCallback );
+
+  std::string meshFile = test_file( "/2dm/quad_and_line.2dm" );
+  MDAL_MeshH m = MDAL_LoadMesh( meshFile.c_str() );
+  EXPECT_NE( m, nullptr );
+  MDAL_Status s = MDAL_LastStatus();
+  EXPECT_EQ( MDAL_Status::None, s );
+  ASSERT_EQ( 2, MDAL_M_datasetGroupCount( m ) );
+
+
+  std::string vertexPath = test_file( "/ascii_dat/quad_and_triangle_vertex_scalar.dat" );
+
+  // add the same dataset multiple times
+  MDAL_M_LoadDatasets( m, vertexPath.c_str() );
+  s = MDAL_LastStatus();
+  EXPECT_EQ( MDAL_Status::None, s );
+  ASSERT_EQ( 3, MDAL_M_datasetGroupCount( m ) );
+
+  MDAL_M_LoadDatasets( m, vertexPath.c_str() );
+  s = MDAL_LastStatus();
+  EXPECT_EQ( MDAL_Status::None, s );
+  ASSERT_EQ( 4, MDAL_M_datasetGroupCount( m ) );
+
+  MDAL_M_LoadDatasets( m, vertexPath.c_str() );
+  s = MDAL_LastStatus();
+  EXPECT_EQ( MDAL_Status::None, s );
+  ASSERT_EQ( 5, MDAL_M_datasetGroupCount( m ) );
+
+  // remove non existing dataset
+  MDAL_M_RemoveDatasetGroup( m, "vertex_scalar" );
+  s = MDAL_LastStatus();
+  EXPECT_EQ( MDAL_Status::Err_InvalidData, s );
+  EXPECT_EQ( receivedLogLevel, MDAL_LogLevel::Error );
+  EXPECT_EQ( receivedLogMessage, "Dataset name is not found in the mesh" );
+
+  // remove existing dataset
+  MDAL_M_RemoveDatasetGroup( m, "VertexScalarDataset" );
+  s = MDAL_LastStatus();
+  EXPECT_EQ( MDAL_Status::None, s );
+  ASSERT_EQ( 4, MDAL_M_datasetGroupCount( m ) );
+
+  MDAL_M_RemoveDatasetGroup( m, "VertexScalarDataset_2" );
+  s = MDAL_LastStatus();
+  EXPECT_EQ( MDAL_Status::None, s );
+  ASSERT_EQ( 3, MDAL_M_datasetGroupCount( m ) );
+}
+
 int main( int argc, char **argv )
 {
   testing::InitGoogleTest( &argc, argv );

--- a/tests/test_api.cpp
+++ b/tests/test_api.cpp
@@ -644,9 +644,9 @@ TEST( ApiTest, DuplicatedDatasetNames )
   EXPECT_EQ( MDAL_Status::None, s );
   ASSERT_EQ( 2, MDAL_M_datasetGroupCount( m ) );
 
- 
+
   std::string vertexPath = test_file( "/ascii_dat/quad_and_triangle_vertex_scalar.dat" );
-  
+
   // add the same dataset multiple times
   MDAL_M_LoadDatasets( m, vertexPath.c_str() );
   s = MDAL_LastStatus();
@@ -665,7 +665,7 @@ TEST( ApiTest, DuplicatedDatasetNames )
 
   // check that the DatasetGroup names are unique
   std::set<std::string> names;
-  for (int i = 0; i < MDAL_M_datasetGroupCount( m ); ++i)
+  for ( int i = 0; i < MDAL_M_datasetGroupCount( m ); ++i )
   {
     MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, i );
     ASSERT_NE( g, nullptr );

--- a/tests/test_api.cpp
+++ b/tests/test_api.cpp
@@ -635,6 +635,47 @@ TEST( ApiTest, MeshCreationApi )
   EXPECT_EQ( std::strcmp( MDAL_DR_saveMeshSuffix( driver ), "slf" ), 0 );
 }
 
+TEST( ApiTest, DuplicatedDatasetNames )
+{
+  std::string meshFile = test_file( "/2dm/quad_and_line.2dm" );
+  MDAL_MeshH m = MDAL_LoadMesh( meshFile.c_str() );
+  EXPECT_NE( m, nullptr );
+  MDAL_Status s = MDAL_LastStatus();
+  EXPECT_EQ( MDAL_Status::None, s );
+  ASSERT_EQ( 2, MDAL_M_datasetGroupCount( m ) );
+
+ 
+  std::string vertexPath = test_file( "/ascii_dat/quad_and_triangle_vertex_scalar.dat" );
+  
+  // add the same dataset multiple times
+  MDAL_M_LoadDatasets( m, vertexPath.c_str() );
+  s = MDAL_LastStatus();
+  EXPECT_EQ( MDAL_Status::None, s );
+  ASSERT_EQ( 3, MDAL_M_datasetGroupCount( m ) );
+
+  MDAL_M_LoadDatasets( m, vertexPath.c_str() );
+  s = MDAL_LastStatus();
+  EXPECT_EQ( MDAL_Status::None, s );
+  ASSERT_EQ( 4, MDAL_M_datasetGroupCount( m ) );
+
+  MDAL_M_LoadDatasets( m, vertexPath.c_str() );
+  s = MDAL_LastStatus();
+  EXPECT_EQ( MDAL_Status::None, s );
+  ASSERT_EQ( 5, MDAL_M_datasetGroupCount( m ) );
+
+  // check that the DatasetGroup names are unique
+  std::set<std::string> names;
+  for (int i = 0; i < MDAL_M_datasetGroupCount( m ); ++i)
+  {
+    MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, i );
+    ASSERT_NE( g, nullptr );
+    std::string name = MDAL_G_name( g );
+    ASSERT_TRUE( names.find( name ) == names.end() );
+    names.insert( name );
+  }
+  ASSERT_EQ( 5, names.size() );
+}
+
 int main( int argc, char **argv )
 {
   testing::InitGoogleTest( &argc, argv );


### PR DESCRIPTION
This makes sure that DatasetGroups for Mesh will always have unique names. 

This will allow adding DatasetGroup with the same name in QGIS - right now such datasets can not be added.