### PR TITLE
Replace regex_split with MDAL::split in mdal_mike21.cpp

### DIFF
--- a/mdal/frmts/mdal_mike21.cpp
+++ b/mdal/frmts/mdal_mike21.cpp
@@ -23,13 +23,6 @@
 
 #define DRIVER_NAME "Mike21"
 
-// function to split using regex, by default split on whitespace characters
-std::vector<std::string> regex_split( const std::string &input, const std::regex &split_regex = std::regex{"\\s+"} )
-{
-  std::sregex_token_iterator iter( input.begin(), input.end(), split_regex, -1 );
-  std::sregex_token_iterator end;
-  return {iter, end};
-}
 
 static bool parse_vertex_id_gaps( std::map<size_t, size_t> &vertexIDtoIndex, size_t vertexIndex, size_t vertexID )
 {
@@ -246,7 +239,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverMike21::load( const std::string &meshFil
   {
     if ( 0 < lineNumber && lineNumber < mVertexCount + 1 )
     {
-      chunks = regex_split( MDAL::trim( line ) );
+      chunks = MDAL::split( MDAL::trim( line ),' ');
       if ( chunks.size() != 5 )
       {
         MDAL::Log::error( MDAL_Status::Err_InvalidData, name(), "vertex line in invalid format." );
@@ -283,7 +276,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverMike21::load( const std::string &meshFil
 
     if ( mVertexCount + 1 < lineNumber )
     {
-      chunks = regex_split( MDAL::trim( line ) );
+      chunks = MDAL::split( MDAL::trim( line ),' ');
       assert( faceIndex < faceCount );
 
       size_t faceVertexCount = chunks.size() - 1;

--- a/mdal/frmts/mdal_mike21.cpp
+++ b/mdal/frmts/mdal_mike21.cpp
@@ -23,6 +23,13 @@
 
 #define DRIVER_NAME "Mike21"
 
+void replaceTabsWithSpaces(std::string& str) {
+    for (size_t i = 0; i < str.length(); ++i) {
+        if (str[i] == '\t') {
+            str[i] = ' ';
+        }
+    }
+}
 
 static bool parse_vertex_id_gaps( std::map<size_t, size_t> &vertexIDtoIndex, size_t vertexIndex, size_t vertexID )
 {
@@ -239,6 +246,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverMike21::load( const std::string &meshFil
   {
     if ( 0 < lineNumber && lineNumber < mVertexCount + 1 )
     {
+      replaceTabsWithSpaces(line);
       chunks = MDAL::split( MDAL::trim( line ),' ');
       if ( chunks.size() != 5 )
       {
@@ -276,6 +284,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverMike21::load( const std::string &meshFil
 
     if ( mVertexCount + 1 < lineNumber )
     {
+      replaceTabsWithSpaces(line);
       chunks = MDAL::split( MDAL::trim( line ),' ');
       assert( faceIndex < faceCount );
 


### PR DESCRIPTION
mike21 dirver  uses regular expressions to analyze text data, it  is very slow.

---
###  regex_split test
$ time ./tools/mdalinfo ./tlgs.mesh
mdalinfo 1.3.0
Mesh File: ./tlgs.mesh
Mesh loaded: OK
  Driver: Mike21
  Vertex count: 146054
  Edge count: 0
  Face count: 279552
  Edge count: 0
  Projection: PROJCS["CGCS2000_3_Degree_GK_CM_117E"]
Datasets loaded: OK
  Groups count: 2
  VertexType
  Bed Elevation

real    0m40.182s
user    0m38.331s
sys     0m0.030s

---
###  MDAL::split test
$ time ./tools/mdalinfo ./tlgs.mesh
mdalinfo 1.3.0
Mesh File: ./tlgs.mesh
Mesh loaded: OK
  Driver: Mike21
  Vertex count: 146054
  Edge count: 0
  Face count: 279552
  Edge count: 0
  Projection: PROJCS["CGCS2000_3_Degree_GK_CM_117E"]
Datasets loaded: OK
  Groups count: 2
  VertexType
  Bed Elevation

real    0m2.458s
user    0m0.800s
sys     0m0.042s
