### PR TITLE
prefer MDAL::split() char variant where possible

### DIFF
--- a/mdal/frmts/mdal_hec2d.cpp
+++ b/mdal/frmts/mdal_hec2d.cpp
@@ -122,7 +122,7 @@ static MDAL::DateTime convertToDateTime( const std::string strDateTime )
 {
   //HECRAS format date is 01JAN2000
 
-  auto data = MDAL::split( strDateTime, " " );
+  auto data = MDAL::split( strDateTime, ' ' );
   if ( data.size() < 2 )
     return MDAL::DateTime();
 

--- a/mdal/frmts/mdal_ugrid.cpp
+++ b/mdal/frmts/mdal_ugrid.cpp
@@ -461,7 +461,7 @@ void MDAL::DriverUgrid::ignore1DMeshVariables( const std::string &mesh, std::set
   for ( const std::string &coordinateIt : coordinateVarsToIgnore )
   {
     std::string coordinatesVar = mNcFile->getAttrStr( mesh, coordinateIt );
-    std::vector<std::string> allCoords = MDAL::split( coordinatesVar, " " );
+    std::vector<std::string> allCoords = MDAL::split( coordinatesVar, ' ' );
 
     for ( const std::string &var : allCoords )
     {
@@ -1041,7 +1041,7 @@ void MDAL::DriverUgrid::writeVariables( MDAL::Mesh *mesh, const std::string &mes
   }
   else
   {
-    std::vector<std::string> words = MDAL::split( mesh->crs(), ":" );
+    std::vector<std::string> words = MDAL::split( mesh->crs(), ':' );
 
     if ( words[0] == "EPSG" && words.size() > 1 )
     {

--- a/mdal/frmts/mdal_xdmf.cpp
+++ b/mdal/frmts/mdal_xdmf.cpp
@@ -359,7 +359,7 @@ void MDAL::DriverXdmf::hdf5NamePath( const std::string &dataItemPath, std::strin
     path.erase( 0, startpos );
   }
 
-  std::vector<std::string> chunks = MDAL::split( path, ":" );
+  std::vector<std::string> chunks = MDAL::split( path, ':' );
   if ( chunks.size() != 2 )
   {
     throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "must be in format fileName:hdfPath" );

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -964,7 +964,7 @@ MDAL::DateTime MDAL::parseCFReferenceTime( const std::string &timeInformation, c
   if ( strings.size() > 3 )
   {
     std::string timeString = strings[3];
-    auto timeStringsValue = MDAL::split( timeString, ":" );
+    auto timeStringsValue = MDAL::split( timeString, ':' );
     if ( timeStringsValue.size() == 3 )
     {
       hours = MDAL::toInt( timeStringsValue[0] );


### PR DESCRIPTION
When splitting by a `char`, use the `MDAL::split()` method that is optimized for chars