### PR TITLE
Fix out of bounds access when reading dat reference time

### DIFF
--- a/mdal/frmts/mdal_binary_dat.cpp
+++ b/mdal/frmts/mdal_binary_dat.cpp
@@ -146,7 +146,6 @@ void MDAL::DriverBinaryDat::load( const std::string &datFile, MDAL::Mesh *mesh )
   int numdata;
   int numcells;
   char groupName[40];
-  double referenceTime;
   int timeUnit = 0;
   std::string timeUnitStr;
   char istat;
@@ -241,16 +240,18 @@ void MDAL::DriverBinaryDat::load( const std::string &datFile, MDAL::Mesh *mesh )
         break;
 
       case CT_RT_JULIAN:
+      {
         // Reference time
         if ( readIStat( in, sflg, &istat ) )
           return exit_with_error( MDAL_Status::Err_UnknownFormat, "unable to read reference time" );
 
-        if ( read( in, reinterpret_cast< char * >( &time ), 8 ) )
+        double referenceTime = 0;
+        if ( read( in, reinterpret_cast< char * >( &referenceTime ), 8 ) )
           return exit_with_error( MDAL_Status::Err_UnknownFormat, "unable to read reference time" );
 
-        referenceTime = static_cast<double>( time );
         group->setReferenceTime( DateTime( referenceTime, DateTime::JulianDay ) );
         break;
+      }
 
       case CT_TIMEUNITS:
         // Time unit

--- a/mdal/frmts/mdal_binary_dat.cpp
+++ b/mdal/frmts/mdal_binary_dat.cpp
@@ -146,10 +146,8 @@ void MDAL::DriverBinaryDat::load( const std::string &datFile, MDAL::Mesh *mesh )
   int numdata;
   int numcells;
   char groupName[40];
-  int timeUnit = 0;
   std::string timeUnitStr;
   char istat;
-  float time;
 
   if ( read( in, reinterpret_cast< char * >( &version ), 4 ) ) return exit_with_error( MDAL_Status::Err_UnknownFormat, "Unable to read version" );
 
@@ -254,7 +252,9 @@ void MDAL::DriverBinaryDat::load( const std::string &datFile, MDAL::Mesh *mesh )
       }
 
       case CT_TIMEUNITS:
+      {
         // Time unit
+        int timeUnit = 0;
         if ( read( in, reinterpret_cast< char * >( &timeUnit ), 4 ) )
           return exit_with_error( MDAL_Status::Err_UnknownFormat, "Unable to read time units" );
 
@@ -278,16 +278,18 @@ void MDAL::DriverBinaryDat::load( const std::string &datFile, MDAL::Mesh *mesh )
         }
         group->setMetadata( "TIMEUNITS", timeUnitStr );
         break;
+      }
 
       case CT_TS:
         // Time step!
         if ( readIStat( in, sflg, &istat ) )
           return exit_with_error( MDAL_Status::Err_UnknownFormat, "Invalid time step" );
 
-        if ( read( in, reinterpret_cast< char * >( &time ), 4 ) )
+        float timeStep;
+        if ( read( in, reinterpret_cast< char * >( &timeStep ), 4 ) )
           return exit_with_error( MDAL_Status::Err_UnknownFormat, "Invalid time step" );
 
-        double rawTime = static_cast<double>( time );
+        double rawTime = static_cast<double>( timeStep );
         MDAL::RelativeTimestamp t( rawTime, MDAL::parseDurationTimeUnit( timeUnitStr ) );
 
         if ( readVertexTimestep( mesh, group, groupMax, t, istat, sflg, in ) )


### PR DESCRIPTION
We can't store an 8 byte result into a 4 byte float value