### PR TITLE
Fix HDF5 dataset loading (handle error codes)

### DIFF
--- a/mdal/frmts/mdal_hdf5.cpp
+++ b/mdal/frmts/mdal_hdf5.cpp
@@ -193,7 +193,17 @@ hid_t HdfDataset::id() const { return d->id; }
 std::vector<hsize_t> HdfDataset::dims() const
 {
   hid_t sid = H5Dget_space( d->id );
-  std::vector<hsize_t> ret( static_cast<size_t>( H5Sget_simple_extent_ndims( sid ) ) );
+  if ( sid == H5I_INVALID_HID )
+    return std::vector<hsize_t>();
+
+  int ndims = H5Sget_simple_extent_ndims( sid );
+  if ( ndims < 0 )
+  {
+    H5Sclose( sid );
+    return std::vector<hsize_t>(); 
+  }
+
+  std::vector<hsize_t> ret( static_cast<size_t>( ndims ) );
   H5Sget_simple_extent_dims( sid, ret.data(), nullptr );
   H5Sclose( sid );
   return ret;

--- a/mdal/frmts/mdal_hdf5.cpp
+++ b/mdal/frmts/mdal_hdf5.cpp
@@ -200,7 +200,7 @@ std::vector<hsize_t> HdfDataset::dims() const
   if ( ndims < 0 )
   {
     H5Sclose( sid );
-    return std::vector<hsize_t>(); 
+    return std::vector<hsize_t>();
   }
 
   std::vector<hsize_t> ret( static_cast<size_t>( ndims ) );


### PR DESCRIPTION
While opening the HDF5 dataset, we check for error codes and possible negative values, so we do not end up static casting them to unsigned ints.

Fixes qgis/QGIS#63216