### PR TITLE
Add MDAL_LF_SkipStatistics load flag and approximate min/max API

### DIFF
--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -414,6 +414,15 @@ MDAL_EXPORT int MDAL_M_faceVerticesMaximumCount( MDAL_MeshH mesh );
 MDAL_EXPORT void MDAL_M_LoadDatasets( MDAL_MeshH mesh, const char *datasetFile );
 
 /**
+ * Loads dataset file like MDAL_M_LoadDatasets, but with extra control over the
+ * loading process via \a flags (a bitwise-OR combination of \ref MDAL_LoadFlag),
+ * mirroring MDAL_LoadMeshWithFlags()
+ *
+ * \since MDAL 1.4.0
+ */
+MDAL_EXPORT void MDAL_M_LoadDatasetsWithFlags( MDAL_MeshH mesh, const char *datasetFile, int flags );
+
+/**
  * Returns number of metadata values
  *
  * \since MDAL 0.9.0

--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -244,6 +244,10 @@ enum MDAL_LoadFlag
    * MDAL_G_minimumMaximumApprox() will compute on-the-fly for the sampled
    * datasets only (fast). This dramatically reduces initial load times for
    * meshes with many timesteps when an exact min/max is not required upfront.
+   *
+   * The deferred computation reads dataset data on demand; like the rest of
+   * MDAL, it is not thread-safe: a given mesh handle must be used from a
+   * single thread at a time.
    */
   MDAL_LF_SkipStatistics = 1 << 0
 };

--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -231,7 +231,7 @@ MDAL_EXPORT int MDAL_DR_faceVerticesMaximumCount( MDAL_DriverH driver );
  *
  * Combine with bitwise OR.
  *
- * \since MDAL 1.4
+ * \since MDAL 1.4.0
  */
 enum MDAL_LoadFlag
 {
@@ -248,6 +248,10 @@ enum MDAL_LoadFlag
    * The deferred computation reads dataset data on demand; like the rest of
    * MDAL, it is not thread-safe: a given mesh handle must be used from a
    * single thread at a time.
+   *
+   * Skipping statistics can also skip driver-side validity filtering based on
+   * them: e.g. XDMF groups without any valid value, normally dropped at load
+   * time, are kept when this flag is set.
    */
   MDAL_LF_SkipStatistics = 1 << 0
 };
@@ -270,7 +274,7 @@ MDAL_EXPORT MDAL_MeshH MDAL_LoadMesh( const char *uri );
  * Currently the only supported flag is MDAL_LF_SkipStatistics, useful to
  * avoid the up-front per-dataset stats scan on large multi-timestep files.
  *
- * \since MDAL 1.4
+ * \since MDAL 1.4.0
  */
 MDAL_EXPORT MDAL_MeshH MDAL_LoadMeshWithFlags( const char *uri, int flags );
 
@@ -673,7 +677,7 @@ MDAL_EXPORT int MDAL_G_maximumVerticalLevelCount( MDAL_DatasetGroupH group );
  * Returns the minimum and maximum values of the group
  * Returns NaN on error
  *
- * \note Since MDAL 1.4, when a mesh was loaded with MDAL_LF_SkipStatistics
+ * \note Since MDAL 1.4.0, when a mesh was loaded with MDAL_LF_SkipStatistics
  * the driver did not pre-compute statistics; the first call to this function
  * for such a group will block to compute the exact range over every dataset
  * (potentially slow). The result is cached so subsequent calls are O(1).
@@ -683,18 +687,23 @@ MDAL_EXPORT void MDAL_G_minimumMaximum( MDAL_DatasetGroupH group, double *min, d
 
 /**
  * Returns an approximate minimum and maximum of the group, computed from a sample
- * of \a sampleCount evenly-spaced datasets (endpoints included). Useful to avoid
- * scanning every timestep on initial display, when an exact range is not required.
+ * of \a sampleCount evenly-spaced datasets (endpoints included; the middle
+ * dataset when \a sampleCount is 1). Useful to avoid scanning every timestep
+ * on initial display, when an exact range is not required.
  *
- * When \a sampleCount is 0 or greater or equal to the dataset count of the group,
- * falls back to MDAL_G_minimumMaximum (exact).
+ * The computation falls back to the exact range of MDAL_G_minimumMaximum()
+ * (cached as such) when \a sampleCount is 0 (or negative) or greater or equal
+ * to the dataset count of the group, and when the sample contains no valid
+ * value (e.g. a domain entirely dry at the sampled times).
  *
- * The returned values are NOT cached into the group statistics, so a later call
- * to MDAL_G_minimumMaximum will still compute and return the exact range.
+ * The approximate values are never cached as the group statistics, so a later
+ * call to MDAL_G_minimumMaximum will still compute and return the exact range.
+ * The statistics of the sampled datasets themselves ARE cached, making repeated
+ * calls cheap and pre-warming a later exact computation.
  *
  * Returns NaN on error
  *
- * \since MDAL 1.4
+ * \since MDAL 1.4.0
  */
 MDAL_EXPORT void MDAL_G_minimumMaximumApprox( MDAL_DatasetGroupH group, int sampleCount, double *min, double *max );
 
@@ -881,6 +890,11 @@ MDAL_EXPORT int MDAL_D_data( MDAL_DatasetH dataset, int indexStart, int count, M
 /**
  * Returns the minimum and maximum values of the dataset
  * Returns NaN on error
+ *
+ * \note Since MDAL 1.4.0, when a mesh was loaded with MDAL_LF_SkipStatistics
+ * the driver did not pre-compute statistics; the first call to this function
+ * for such a dataset will block to compute the exact range over its values.
+ * The result is cached so subsequent calls are O(1).
  */
 MDAL_EXPORT void MDAL_D_minimumMaximum( MDAL_DatasetH dataset, double *min, double *max );
 

--- a/mdal/api/mdal.h
+++ b/mdal/api/mdal.h
@@ -227,6 +227,28 @@ MDAL_EXPORT int MDAL_DR_faceVerticesMaximumCount( MDAL_DriverH driver );
 ///////////////////////////////////////////////////////////////////////////////////////
 
 /**
+ * Flags controlling MDAL_LoadMeshWithFlags() behavior.
+ *
+ * Combine with bitwise OR.
+ *
+ * \since MDAL 1.4
+ */
+enum MDAL_LoadFlag
+{
+  /**
+   * Skip the eager per-dataset and per-group statistics computation usually
+   * performed by drivers during load.
+   *
+   * When this flag is set, MDAL_G_minimumMaximum() will compute and cache
+   * the exact range on first call (potentially slow), and
+   * MDAL_G_minimumMaximumApprox() will compute on-the-fly for the sampled
+   * datasets only (fast). This dramatically reduces initial load times for
+   * meshes with many timesteps when an exact min/max is not required upfront.
+   */
+  MDAL_LF_SkipStatistics = 1 << 0
+};
+
+/**
  * Loads mesh file. On error see MDAL_LastStatus for error type
  * This may effectively load whole mesh in-memory for some providers
  * Caller must free memory with MDAL_CloseMesh() afterwards
@@ -236,6 +258,17 @@ MDAL_EXPORT int MDAL_DR_faceVerticesMaximumCount( MDAL_DriverH driver );
  * examples: Ugrid:"mesh.nc":0, Ugrid:"mesh.nc":mesh1d, "mesh.nc":mesh1d, Ugrid:"mesh.nc", "mesh.nc", mesh.nc
  */
 MDAL_EXPORT MDAL_MeshH MDAL_LoadMesh( const char *uri );
+
+/**
+ * Loads mesh file like MDAL_LoadMesh, but with extra control over the
+ * loading process via \a flags (a bitwise-OR combination of \ref MDAL_LoadFlag).
+ *
+ * Currently the only supported flag is MDAL_LF_SkipStatistics, useful to
+ * avoid the up-front per-dataset stats scan on large multi-timestep files.
+ *
+ * \since MDAL 1.4
+ */
+MDAL_EXPORT MDAL_MeshH MDAL_LoadMeshWithFlags( const char *uri, int flags );
 
 /**
  * Returns uris that the resource contains (mesh names)
@@ -626,8 +659,31 @@ MDAL_EXPORT int MDAL_G_maximumVerticalLevelCount( MDAL_DatasetGroupH group );
 /**
  * Returns the minimum and maximum values of the group
  * Returns NaN on error
+ *
+ * \note Since MDAL 1.4, when a mesh was loaded with MDAL_LF_SkipStatistics
+ * the driver did not pre-compute statistics; the first call to this function
+ * for such a group will block to compute the exact range over every dataset
+ * (potentially slow). The result is cached so subsequent calls are O(1).
+ * Use MDAL_G_minimumMaximumApprox() if you only need a quick estimate.
  */
 MDAL_EXPORT void MDAL_G_minimumMaximum( MDAL_DatasetGroupH group, double *min, double *max );
+
+/**
+ * Returns an approximate minimum and maximum of the group, computed from a sample
+ * of \a sampleCount evenly-spaced datasets (endpoints included). Useful to avoid
+ * scanning every timestep on initial display, when an exact range is not required.
+ *
+ * When \a sampleCount is 0 or greater or equal to the dataset count of the group,
+ * falls back to MDAL_G_minimumMaximum (exact).
+ *
+ * The returned values are NOT cached into the group statistics, so a later call
+ * to MDAL_G_minimumMaximum will still compute and return the exact range.
+ *
+ * Returns NaN on error
+ *
+ * \since MDAL 1.4
+ */
+MDAL_EXPORT void MDAL_G_minimumMaximumApprox( MDAL_DatasetGroupH group, int sampleCount, double *min, double *max );
 
 /**
  * Adds empty (new) dataset to the group

--- a/mdal/frmts/mdal_3di.cpp
+++ b/mdal/frmts/mdal_3di.cpp
@@ -270,9 +270,9 @@ void MDAL::Driver3Di::addBedElevation( MemoryMesh *mesh )
     }
   }
 
-  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  MDAL::setStatisticsIfRequired( dataset, loadFlags() );
   group->datasets.push_back( dataset );
-  group->setStatistics( MDAL::calculateStatistics( group ) );
+  MDAL::setStatisticsIfRequired( group, loadFlags() );
   mesh->datasetGroups.emplace_back( std::move( group ) );
 }
 
@@ -303,7 +303,7 @@ std::shared_ptr<MDAL::Dataset> MDAL::Driver3Di::create2DDataset( std::shared_ptr
         mNcFile,
         mRequestedMeshFaceIds
       );
-  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  MDAL::setStatisticsIfRequired( dataset, loadFlags() );
   return std::move( dataset );
 }
 

--- a/mdal/frmts/mdal_ascii_dat.cpp
+++ b/mdal/frmts/mdal_ascii_dat.cpp
@@ -142,7 +142,7 @@ void MDAL::DriverAsciiDat::loadOldFormat( std::ifstream &in,
     return;
   }
 
-  group->setStatistics( MDAL::calculateStatistics( group ) );
+  MDAL::setStatisticsIfRequired( group, loadFlags() );
   mesh->datasetGroups.push_back( group );
   group.reset();
 }
@@ -244,7 +244,7 @@ void MDAL::DriverAsciiDat::loadNewFormat(
         MDAL::Log::error( MDAL_Status::Err_UnknownFormat, name(), "ENDDS card for no active dataset!" );
         return;
       }
-      group->setStatistics( MDAL::calculateStatistics( group ) );
+      MDAL::setStatisticsIfRequired( group, loadFlags() );
       mesh->datasetGroups.push_back( group );
       group.reset();
     }
@@ -429,7 +429,7 @@ void MDAL::DriverAsciiDat::readVertexTimestep(
     }
   }
 
-  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  MDAL::setStatisticsIfRequired( dataset, loadFlags() );
   group->datasets.push_back( dataset );
 }
 
@@ -474,7 +474,7 @@ void MDAL::DriverAsciiDat::readElementTimestep(
     }
   }
 
-  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  MDAL::setStatisticsIfRequired( dataset, loadFlags() );
   group->datasets.push_back( dataset );
 }
 

--- a/mdal/frmts/mdal_binary_dat.cpp
+++ b/mdal/frmts/mdal_binary_dat.cpp
@@ -302,12 +302,12 @@ void MDAL::DriverBinaryDat::load( const std::string &datFile, MDAL::Mesh *mesh )
   if ( group->datasets.size() == 0 )
     return exit_with_error( MDAL_Status::Err_UnknownFormat, "No datasets" );
 
-  group->setStatistics( MDAL::calculateStatistics( group ) );
+  MDAL::setStatisticsIfRequired( group, loadFlags() );
   mesh->datasetGroups.emplace_back( std::move( group ) );
 
   if ( groupMax->datasets.size() > 0 )
   {
-    groupMax->setStatistics( MDAL::calculateStatistics( groupMax ) );
+    MDAL::setStatisticsIfRequired( groupMax, loadFlags() );
     mesh->datasetGroups.emplace_back( std::move( groupMax ) );
   }
 }
@@ -367,13 +367,13 @@ bool MDAL::DriverBinaryDat::readVertexTimestep(
   if ( MDAL::equals( time.value( MDAL::RelativeTimestamp::hours ), 99999.0 ) ) // Special TUFLOW dataset with maximus
   {
     dataset->setTime( time );
-    dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+    MDAL::setStatisticsIfRequired( dataset, loadFlags() );
     groupMax->datasets.push_back( dataset );
   }
   else
   {
     dataset->setTime( time );
-    dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+    MDAL::setStatisticsIfRequired( dataset, loadFlags() );
     group->datasets.push_back( dataset );
   }
   return false; //OK

--- a/mdal/frmts/mdal_cf.cpp
+++ b/mdal/frmts/mdal_cf.cpp
@@ -380,7 +380,7 @@ void MDAL::DriverCF::addDatasetGroups( MDAL::Mesh *mesh, const std::vector<Relat
     // Add to mesh
     if ( !group->datasets.empty() )
     {
-      group->setStatistics( MDAL::calculateStatistics( group ) );
+      MDAL::setStatisticsIfRequired( group, loadFlags() );
       group->setReferenceTime( referenceTime );
       mesh->datasetGroups.emplace_back( std::move( group ) );
     }
@@ -434,7 +434,7 @@ std::shared_ptr<MDAL::Dataset> MDAL::DriverCF::create2DDataset( std::shared_ptr<
         ts,
         mNcFile
       );
-  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  MDAL::setStatisticsIfRequired( dataset, loadFlags() );
   return std::move( dataset );
 }
 

--- a/mdal/frmts/mdal_driver.cpp
+++ b/mdal/frmts/mdal_driver.cpp
@@ -74,6 +74,10 @@ bool MDAL::Driver::hasWriteDatasetCapability( MDAL_DataLocation location ) const
 
 int MDAL::Driver::faceVerticesMaximumCount() const { return -1; }
 
+void MDAL::Driver::setLoadFlags( int flags ) { mLoadFlags = flags; }
+
+int MDAL::Driver::loadFlags() const { return mLoadFlags; }
+
 std::string MDAL::Driver::buildUri( const std::string &meshFile )
 {
   return MDAL::buildMeshUri( meshFile, "", this->name() );

--- a/mdal/frmts/mdal_driver.hpp
+++ b/mdal/frmts/mdal_driver.hpp
@@ -85,11 +85,16 @@ namespace MDAL
       // returns true on error, false on success
       virtual bool persist( DatasetGroup *group );
 
+      //! Bitwise OR of MDAL_LoadFlag values, set by DriverManager before load().
+      void setLoadFlags( int flags );
+      int loadFlags() const;
+
     private:
       std::string mName;
       std::string mLongName;
       std::string mFilters;
       int mCapabilityFlags;
+      int mLoadFlags = 0;
   };
 
 } // namespace MDAL

--- a/mdal/frmts/mdal_dynamic_driver.cpp
+++ b/mdal/frmts/mdal_dynamic_driver.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverDynamic::load( const std::string &uri, c
       {
         mMeshIds.insert( meshId );
         mesh->setProjection();
-        if ( mesh->populateDatasetGroups() )
+        if ( mesh->populateDatasetGroups( loadFlags() ) )
           return mesh;
       }
     }
@@ -184,7 +184,7 @@ void MDAL::MeshDynamicDriver::setProjection()
   setSourceCrs( projection );
 }
 
-bool MDAL::MeshDynamicDriver::populateDatasetGroups()
+bool MDAL::MeshDynamicDriver::populateDatasetGroups( int loadFlags )
 {
   if ( !mMeshDatasetGroupsCountFunction )
     return false;
@@ -258,7 +258,7 @@ bool MDAL::MeshDynamicDriver::populateDatasetGroups()
           if ( !dataset2D->loadSymbol() )
             return false;
 
-          dataset2D->setStatistics( MDAL::calculateStatistics( dataset2D ) );
+          MDAL::setStatisticsIfRequired( dataset2D, loadFlags );
           dataset2D->unloadData();
           dataset = dataset2D;
         }
@@ -273,7 +273,7 @@ bool MDAL::MeshDynamicDriver::populateDatasetGroups()
           if ( ! dataset3D->loadSymbol() )
             return false;
 
-          dataset3D->setStatistics( MDAL::calculateStatistics( dataset3D ) );
+          MDAL::setStatisticsIfRequired( dataset3D, loadFlags );
           dataset3D->unloadData();
           dataset = dataset3D;
         }
@@ -289,7 +289,7 @@ bool MDAL::MeshDynamicDriver::populateDatasetGroups()
       group->datasets.emplace_back( std::move( dataset ) );
     }
 
-    group->setStatistics( MDAL::calculateStatistics( group ) );
+    MDAL::setStatisticsIfRequired( group, loadFlags );
     datasetGroups.emplace_back( std::move( group ) );
   }
   return true;

--- a/mdal/frmts/mdal_dynamic_driver.hpp
+++ b/mdal/frmts/mdal_dynamic_driver.hpp
@@ -144,6 +144,8 @@ namespace MDAL
       size_t vectorData( size_t indexStart, size_t count, double *buffer ) override;
       size_t activeData( size_t indexStart, size_t count, int *buffer ) override;
 
+      void releaseLoadedData() override { unloadData(); }
+
     private:
 
       std::function<int ( int, int, int, int, int, int * )> mActiveFlagsFunction;
@@ -167,6 +169,8 @@ namespace MDAL
       size_t faceToVolumeData( size_t indexStart, size_t count, int *buffer ) override;
       size_t scalarVolumesData( size_t indexStart, size_t count, double *buffer ) override;
       size_t vectorVolumesData( size_t indexStart, size_t count, double *buffer ) override;
+
+      void releaseLoadedData() override { unloadData(); }
 
     private:
 

--- a/mdal/frmts/mdal_dynamic_driver.hpp
+++ b/mdal/frmts/mdal_dynamic_driver.hpp
@@ -197,7 +197,7 @@ namespace MDAL
       //! Set the projection from the source
       void setProjection();
 
-      bool populateDatasetGroups();
+      bool populateDatasetGroups( int loadFlags );
 
       //! Returns whether all the symbols have been loaded
       bool loadSymbol();

--- a/mdal/frmts/mdal_flo2d.cpp
+++ b/mdal/frmts/mdal_flo2d.cpp
@@ -79,9 +79,9 @@ void MDAL::DriverFlo2D::addStaticDataset(
   dataset->setTime( MDAL::RelativeTimestamp() );
   double *values = dataset->values();
   memcpy( values, vals.data(), vals.size() * sizeof( double ) );
-  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  MDAL::setStatisticsIfRequired( dataset, loadFlags() );
   group->datasets.push_back( dataset );
-  group->setStatistics( MDAL::calculateStatistics( group ) );
+  MDAL::setStatisticsIfRequired( group, loadFlags() );
   mMesh->datasetGroups.emplace_back( std::move( group ) );
 }
 
@@ -397,9 +397,9 @@ void MDAL::DriverFlo2D::parseHYCHANFile( const std::string &datFileName, const s
   for ( std::shared_ptr<DatasetGroup> datasetGroup : datasetGroups )
   {
     for ( std::shared_ptr<Dataset> dataset : datasetGroup->datasets )
-      dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+      MDAL::setStatisticsIfRequired( dataset, loadFlags() );
 
-    datasetGroup->setStatistics( MDAL::calculateStatistics( datasetGroup ) );
+    MDAL::setStatisticsIfRequired( datasetGroup, loadFlags() );
     mMesh->datasetGroups.emplace_back( std::move( datasetGroup ) );
   }
 }
@@ -553,11 +553,11 @@ void MDAL::DriverFlo2D::parseFPLAINFile( std::vector<double> &elevations,
     throw MDAL::Error( MDAL_Status::Err_IncompatibleMesh, "Only isolated cell(s), not possible to calculate cell size" );
 }
 
-static void addDatasetToGroup( std::shared_ptr<MDAL::DatasetGroup> group, std::shared_ptr<MDAL::MemoryDataset2D> dataset )
+static void addDatasetToGroup( std::shared_ptr<MDAL::DatasetGroup> group, std::shared_ptr<MDAL::MemoryDataset2D> dataset, int loadFlags )
 {
   if ( group && dataset && dataset->valuesCount() > 0 )
   {
-    dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+    MDAL::setStatisticsIfRequired( dataset, loadFlags );
     group->datasets.push_back( dataset );
   }
 }
@@ -624,9 +624,9 @@ void MDAL::DriverFlo2D::parseTIMDEPFile( const std::string &datFileName, const s
     {
       time = RelativeTimestamp( MDAL::toDouble( line ), RelativeTimestamp::hours );
 
-      if ( depthDataset ) addDatasetToGroup( depthDsGroup, depthDataset );
-      if ( flowDataset ) addDatasetToGroup( flowDsGroup, flowDataset );
-      if ( waterLevelDataset ) addDatasetToGroup( waterLevelDsGroup, waterLevelDataset );
+      if ( depthDataset ) addDatasetToGroup( depthDsGroup, depthDataset, loadFlags() );
+      if ( flowDataset ) addDatasetToGroup( flowDsGroup, flowDataset, loadFlags() );
+      if ( waterLevelDataset ) addDatasetToGroup( waterLevelDsGroup, waterLevelDataset, loadFlags() );
 
       depthDataset  = std::make_shared< MemoryDataset2D >( depthDsGroup.get() );
       flowDataset = std::make_shared< MemoryDataset2D >( flowDsGroup.get() );
@@ -662,13 +662,13 @@ void MDAL::DriverFlo2D::parseTIMDEPFile( const std::string &datFileName, const s
     }
   }
 
-  if ( depthDataset ) addDatasetToGroup( depthDsGroup, std::move( depthDataset ) );
-  if ( flowDataset ) addDatasetToGroup( flowDsGroup, std::move( flowDataset ) );
-  if ( waterLevelDataset ) addDatasetToGroup( waterLevelDsGroup, std::move( waterLevelDataset ) );
+  if ( depthDataset ) addDatasetToGroup( depthDsGroup, std::move( depthDataset ), loadFlags() );
+  if ( flowDataset ) addDatasetToGroup( flowDsGroup, std::move( flowDataset ), loadFlags() );
+  if ( waterLevelDataset ) addDatasetToGroup( waterLevelDsGroup, std::move( waterLevelDataset ), loadFlags() );
 
-  depthDsGroup->setStatistics( MDAL::calculateStatistics( depthDsGroup ) );
-  flowDsGroup->setStatistics( MDAL::calculateStatistics( flowDsGroup ) );
-  waterLevelDsGroup->setStatistics( MDAL::calculateStatistics( waterLevelDsGroup ) );
+  MDAL::setStatisticsIfRequired( depthDsGroup, loadFlags() );
+  MDAL::setStatisticsIfRequired( flowDsGroup, loadFlags() );
+  MDAL::setStatisticsIfRequired( waterLevelDsGroup, loadFlags() );
 
   mMesh->datasetGroups.emplace_back( std::move( depthDsGroup ) );
   mMesh->datasetGroups.emplace_back( std::move( flowDsGroup ) );
@@ -992,11 +992,11 @@ bool MDAL::DriverFlo2D::parseHDF5Datasets( MemoryMesh *mesh, const std::string &
           output->setScalarValue( i, val );
         }
       }
-      addDatasetToGroup( ds, std::move( output ) );
+      addDatasetToGroup( ds, std::move( output ), loadFlags() );
     }
 
     // TODO use mins & maxs arrays
-    ds->setStatistics( MDAL::calculateStatistics( ds ) );
+    MDAL::setStatisticsIfRequired( ds, loadFlags() );
     mesh->datasetGroups.emplace_back( std::move( ds ) );
 
   }

--- a/mdal/frmts/mdal_gdal.cpp
+++ b/mdal/frmts/mdal_gdal.cpp
@@ -427,12 +427,12 @@ void MDAL::DriverGdal::addDatasetGroups()
         addDataToOutput( raster_bands[i], dataset, is_vector, i == 0 );
       }
       dataset->activateFaces( mMesh.get() );
-      dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+      MDAL::setStatisticsIfRequired( dataset, loadFlags() );
       group->datasets.push_back( dataset );
     }
 
     // TODO use GDALComputeRasterMinMax
-    group->setStatistics( MDAL::calculateStatistics( group ) );
+    MDAL::setStatisticsIfRequired( group, loadFlags() );
     group->setReferenceTime( referenceTime() );
     mMesh->datasetGroups.emplace_back( std::move( group ) );
   }

--- a/mdal/frmts/mdal_h2i.cpp
+++ b/mdal/frmts/mdal_h2i.cpp
@@ -306,7 +306,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverH2i::load( const std::string &meshFile, 
         for ( size_t datasetIndex = 0; datasetIndex < timeSteps.size(); ++datasetIndex )
         {
           std::shared_ptr<DatasetH2iScalar> dataset = std::make_shared<DatasetH2iScalar>( group.get(), in, datasetIndex );
-          dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+          MDAL::setStatisticsIfRequired( dataset, loadFlags() );
           group->datasets.push_back( dataset );
           dataset->clear(); // Lazy loading, so we clear the loaded data during statistic calculation
           dataset->setTime( timeSteps.at( datasetIndex ) );
@@ -317,14 +317,14 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverH2i::load( const std::string &meshFile, 
         for ( size_t datasetIndex = 0; datasetIndex < timeSteps.size(); ++datasetIndex )
         {
           std::shared_ptr<DatasetH2iVector> dataset = std::make_shared<DatasetH2iVector>( group.get(), in, datasetIndex );
-          dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+          MDAL::setStatisticsIfRequired( dataset, loadFlags() );
           group->datasets.push_back( dataset );
           dataset->clear();
           dataset->setTime( timeSteps.at( datasetIndex ) );
         }
       }
 
-      group->setStatistics( MDAL::calculateStatistics( group ) );
+      MDAL::setStatisticsIfRequired( group, loadFlags() );
       mesh->datasetGroups.emplace_back( std::move( group ) );
     }
   }

--- a/mdal/frmts/mdal_h2i.hpp
+++ b/mdal/frmts/mdal_h2i.hpp
@@ -88,6 +88,7 @@ namespace MDAL
       DatasetH2i( DatasetGroup *grp, std::shared_ptr<std::ifstream> in, size_t datasetIndex );
 
       void clear();
+      void releaseLoadedData() override { clear(); }
 
     protected:
 

--- a/mdal/frmts/mdal_hec2d.cpp
+++ b/mdal/frmts/mdal_hec2d.cpp
@@ -353,10 +353,10 @@ void MDAL::DriverHec2D::readFaceOutput( const HdfFile &hdfFile,
 
   for ( auto &dataset : datasets )
   {
-    dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+    MDAL::setStatisticsIfRequired( dataset, loadFlags() );
     group->datasets.push_back( dataset );
   }
-  group->setStatistics( MDAL::calculateStatistics( group ) );
+  MDAL::setStatisticsIfRequired( group, loadFlags() );
   mMesh->datasetGroups.emplace_back( std::move( group ) );
 }
 
@@ -470,10 +470,10 @@ std::shared_ptr<MDAL::MemoryDataset2D> MDAL::DriverHec2D::readElemOutput( const 
 
   for ( auto &dataset : datasets )
   {
-    dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+    MDAL::setStatisticsIfRequired( dataset, loadFlags() );
     group->datasets.push_back( dataset );
   }
-  group->setStatistics( MDAL::calculateStatistics( group ) );
+  MDAL::setStatisticsIfRequired( group, loadFlags() );
   mMesh->datasetGroups.emplace_back( std::move( group ) );
 
   return datasets[0];

--- a/mdal/frmts/mdal_ply.cpp
+++ b/mdal/frmts/mdal_ply.cpp
@@ -453,7 +453,7 @@ std::shared_ptr< MDAL::DatasetGroup> MDAL::DriverPly::addDatasetGroup( MDAL::Mes
   std::shared_ptr< DatasetGroup > group = std::make_shared< DatasetGroup >( mesh->driverName(), mesh, name, name );
   group->setDataLocation( location );
   group->setIsScalar( isScalar );
-  group->setStatistics( MDAL::calculateStatistics( group ) );
+  MDAL::setStatisticsIfRequired( group, loadFlags() );
   mesh->datasetGroups.push_back( group );
   return group;
 }
@@ -508,9 +508,9 @@ void MDAL::DriverPly::addDataset2D( MDAL::DatasetGroup *group, const std::vector
   std::shared_ptr< MDAL::MemoryDataset2D > dataset = std::make_shared< MemoryDataset2D >( group );
   dataset->setTime( 0.0 );
   memcpy( dataset->values(), values.data(), sizeof( double ) * values.size() );
-  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  MDAL::setStatisticsIfRequired( dataset, loadFlags() );
   group->datasets.push_back( dataset );
-  group->setStatistics( MDAL::calculateStatistics( group ) );
+  MDAL::setStatisticsIfRequired( group, loadFlags() );
 }
 
 void MDAL::DriverPly::addDataset3D( MDAL::DatasetGroup *group,
@@ -545,9 +545,9 @@ void MDAL::DriverPly::addDataset3D( MDAL::DatasetGroup *group,
   std::shared_ptr< MDAL::MemoryDataset3D > dataset = std::make_shared< MemoryDataset3D >( group, values.size(), maxVerticalLevelCount, valueIndexes.data(), levels.data() );
   dataset->setTime( 0.0 );
   memcpy( dataset->values(), values.data(), sizeof( double ) * values.size() );
-  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  MDAL::setStatisticsIfRequired( dataset, loadFlags() );
   group->datasets.push_back( dataset );
-  group->setStatistics( MDAL::calculateStatistics( group ) );
+  MDAL::setStatisticsIfRequired( group, loadFlags() );
 }
 
 void MDAL::DriverPly::save( const std::string &fileName, const std::string &meshName, Mesh *mesh )

--- a/mdal/frmts/mdal_selafin.cpp
+++ b/mdal/frmts/mdal_selafin.cpp
@@ -242,19 +242,19 @@ std::vector<double> MDAL::SelafinFile::vertices( size_t offset, size_t count )
   return coordinates;
 }
 
-std::unique_ptr<MDAL::Mesh> MDAL::SelafinFile::createMesh( const std::string &fileName )
+std::unique_ptr<MDAL::Mesh> MDAL::SelafinFile::createMesh( const std::string &fileName, int loadFlags )
 {
   std::shared_ptr<SelafinFile> reader = std::make_shared<SelafinFile>( fileName );
   reader->initialize();
   reader->parseFile();
 
   std::unique_ptr<Mesh> mesh( new MeshSelafin( fileName, reader ) );
-  populateDataset( mesh.get(), std::move( reader ) );
+  populateDataset( mesh.get(), std::move( reader ), loadFlags );
 
   return mesh;
 }
 
-void MDAL::SelafinFile::populateDataset( MDAL::Mesh *mesh, const std::string &fileName )
+void MDAL::SelafinFile::populateDataset( MDAL::Mesh *mesh, const std::string &fileName, int loadFlags )
 {
   std::shared_ptr<SelafinFile> reader = std::make_shared<SelafinFile>( fileName );
   reader->initialize();
@@ -263,7 +263,7 @@ void MDAL::SelafinFile::populateDataset( MDAL::Mesh *mesh, const std::string &fi
   if ( mesh->verticesCount() != reader->verticesCount() || mesh->facesCount() != reader->facesCount() )
     throw MDAL::Error( MDAL_Status::Err_IncompatibleDataset, "Faces or vertices counts in the file are not the same" );
 
-  populateDataset( mesh, std::move( reader ) );
+  populateDataset( mesh, std::move( reader ), loadFlags );
 }
 
 size_t MDAL::SelafinFile::facesCount()
@@ -297,7 +297,7 @@ std::vector<double> MDAL::SelafinFile::datasetValues( size_t timeStepIndex, size
     return std::vector<double>();
 }
 
-void MDAL::SelafinFile::populateDataset( MDAL::Mesh *mesh, std::shared_ptr<MDAL::SelafinFile> reader )
+void MDAL::SelafinFile::populateDataset( MDAL::Mesh *mesh, std::shared_ptr<MDAL::SelafinFile> reader, int loadFlags )
 {
   std::map<std::string, std::shared_ptr<DatasetGroup>> groupsByName;
   std::vector< std::shared_ptr<DatasetGroup>> groupsInOrder;
@@ -392,17 +392,12 @@ void MDAL::SelafinFile::populateDataset( MDAL::Mesh *mesh, std::shared_ptr<MDAL:
     }
   }
 
-  // now calculate statistics
   for ( const std::shared_ptr<DatasetGroup> &group : groupsInOrder )
   {
     for ( const std::shared_ptr<Dataset> &dataset : group->datasets )
-    {
-      MDAL::Statistics stats = MDAL::calculateStatistics( dataset );
-      dataset->setStatistics( stats );
-    }
+      MDAL::setStatisticsIfRequired( dataset, loadFlags );
 
-    MDAL::Statistics stats = MDAL::calculateStatistics( group );
-    group->setStatistics( stats );
+    MDAL::setStatisticsIfRequired( group, loadFlags );
   }
 
   // As everything seems to be ok (no exception thrown), push the groups in the mesh
@@ -662,7 +657,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverSelafin::load( const std::string &meshFi
 
   try
   {
-    mesh = SelafinFile::createMesh( meshFile );
+    mesh = SelafinFile::createMesh( meshFile, loadFlags() );
   }
   catch ( MDAL_Status error )
   {
@@ -683,7 +678,7 @@ void MDAL::DriverSelafin::load( const std::string &datFile, MDAL::Mesh *mesh )
 
   try
   {
-    SelafinFile::populateDataset( mesh, datFile );
+    SelafinFile::populateDataset( mesh, datFile, loadFlags() );
   }
   catch ( MDAL_Status error )
   {

--- a/mdal/frmts/mdal_selafin.hpp
+++ b/mdal/frmts/mdal_selafin.hpp
@@ -45,9 +45,9 @@ namespace MDAL
       SelafinFile( const std::string &fileName );
 
       //! Returns a mesh created with the file
-      static std::unique_ptr<Mesh> createMesh( const std::string &fileName, int loadFlags = 0 );
+      static std::unique_ptr<Mesh> createMesh( const std::string &fileName, int loadFlags );
       //! Populates the mesh with dataset from the file
-      static void populateDataset( Mesh *mesh, const std::string &fileName, int loadFlags = 0 );
+      static void populateDataset( Mesh *mesh, const std::string &fileName, int loadFlags );
 
       //! Extracts data related to the mesh frame for the file
       void parseMeshFrame();
@@ -136,7 +136,7 @@ namespace MDAL
       std::string readStringWithoutLength( size_t len );
       void ignore( int len );
 
-      static void populateDataset( Mesh *mesh, std::shared_ptr<SelafinFile> reader, int loadFlags = 0 );
+      static void populateDataset( Mesh *mesh, std::shared_ptr<SelafinFile> reader, int loadFlags );
 
       // ///////
       //  attribute updated by parseFile() method

--- a/mdal/frmts/mdal_selafin.hpp
+++ b/mdal/frmts/mdal_selafin.hpp
@@ -45,9 +45,9 @@ namespace MDAL
       SelafinFile( const std::string &fileName );
 
       //! Returns a mesh created with the file
-      static std::unique_ptr<Mesh> createMesh( const std::string &fileName );
+      static std::unique_ptr<Mesh> createMesh( const std::string &fileName, int loadFlags = 0 );
       //! Populates the mesh with dataset from the file
-      static void populateDataset( Mesh *mesh, const std::string &fileName );
+      static void populateDataset( Mesh *mesh, const std::string &fileName, int loadFlags = 0 );
 
       //! Extracts data related to the mesh frame for the file
       void parseMeshFrame();
@@ -136,7 +136,7 @@ namespace MDAL
       std::string readStringWithoutLength( size_t len );
       void ignore( int len );
 
-      static void populateDataset( Mesh *mesh, std::shared_ptr<SelafinFile> reader );
+      static void populateDataset( Mesh *mesh, std::shared_ptr<SelafinFile> reader, int loadFlags = 0 );
 
       // ///////
       //  attribute updated by parseFile() method

--- a/mdal/frmts/mdal_sww.cpp
+++ b/mdal/frmts/mdal_sww.cpp
@@ -313,7 +313,7 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverSWW::readScalarGroup(
       {
         o->setScalarValue( i, valuesX[i] );
       }
-      o->setStatistics( MDAL::calculateStatistics( o ) );
+      MDAL::setStatisticsIfRequired( o, loadFlags() );
       mds->datasets.push_back( o );
     }
     else
@@ -333,11 +333,11 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverSWW::readScalarGroup(
         count[0] = 1;
         count[1] = nPoints;
         nc_get_vars_double( ncFile.handle(), varxid, start, count, stride, values );
-        mto->setStatistics( MDAL::calculateStatistics( mto ) );
+        MDAL::setStatisticsIfRequired( mto, loadFlags() );
         mds->datasets.push_back( mto );
       }
     }
-    mds->setStatistics( MDAL::calculateStatistics( mds ) );
+    MDAL::setStatisticsIfRequired( mds, loadFlags() );
   }
 
   return mds;
@@ -389,7 +389,7 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverSWW::readVectorGroup(
       {
         o->setVectorValue( i, valuesX[i], valuesY[i] );
       }
-      o->setStatistics( MDAL::calculateStatistics( o ) );
+      MDAL::setStatisticsIfRequired( o, loadFlags() );
       mds->datasets.push_back( o );
     }
     else
@@ -416,11 +416,11 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverSWW::readVectorGroup(
           mto->setVectorValue( i, static_cast<double>( valuesX[i] ),  static_cast<double>( valuesY[i] ) );
         }
 
-        mto->setStatistics( MDAL::calculateStatistics( mto ) );
+        MDAL::setStatisticsIfRequired( mto, loadFlags() );
         mds->datasets.push_back( mto );
       }
     }
-    mds->setStatistics( MDAL::calculateStatistics( mds ) );
+    MDAL::setStatisticsIfRequired( mds, loadFlags() );
   }
 
   return mds;

--- a/mdal/frmts/mdal_tuflowfv.cpp
+++ b/mdal/frmts/mdal_tuflowfv.cpp
@@ -541,7 +541,7 @@ std::shared_ptr<MDAL::Dataset> MDAL::DriverTuflowFV::create2DDataset(
         ts,
         mNcFile
       );
-  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  MDAL::setStatisticsIfRequired( dataset, loadFlags() );
   return std::move( dataset );
 }
 
@@ -568,7 +568,7 @@ std::shared_ptr<MDAL::Dataset> MDAL::DriverTuflowFV::create3DDataset( std::share
         mNcFile
       );
 
-  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+  MDAL::setStatisticsIfRequired( dataset, loadFlags() );
   return std::move( dataset );
 }
 

--- a/mdal/frmts/mdal_xdmf.cpp
+++ b/mdal/frmts/mdal_xdmf.cpp
@@ -556,21 +556,18 @@ MDAL::DatasetGroups MDAL::DriverXdmf::parseXdmfXml( )
       throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Invalid group, missing timesteps" );
     }
 
-    // Verify the integrity of the dataset by computing the group's exact stats
-    // (cheap once each dataset has its own cached stats from the loop above).
-    // When MDAL_LF_SkipStatistics is set, we skip both the cache write AND the
-    // empty-group filter — the group is computed lazily on first access instead.
-    if ( loadFlags() & MDAL_LF_SkipStatistics )
-    {
-      ret.emplace_back( std::move( grp ) );
-    }
-    else
+    // Verify the integrity of the group by computing its exact stats (cheap
+    // once each dataset has its own cached stats from the loop above). With
+    // MDAL_LF_SkipStatistics both the cache write and this empty-group filter
+    // are skipped; the group is computed lazily on first access instead.
+    if ( !( loadFlags() & MDAL_LF_SkipStatistics ) )
     {
       const MDAL::Statistics stats = MDAL::calculateStatistics( grp );
       grp->setStatistics( stats );
-      if ( !std::isnan( stats.minimum ) )
-        ret.emplace_back( std::move( grp ) );
+      if ( std::isnan( stats.minimum ) )
+        continue;
     }
+    ret.emplace_back( std::move( grp ) );
   }
 
   return ret;

--- a/mdal/frmts/mdal_xdmf.cpp
+++ b/mdal/frmts/mdal_xdmf.cpp
@@ -517,9 +517,9 @@ MDAL::DatasetGroups MDAL::DriverXdmf::parseXdmfXml( )
           xdmfFunctionDataset->swap();
         }
 
-        // This basically forces to load all data to calculate statistics!
-        const MDAL::Statistics stats = MDAL::calculateStatistics( xdmfFunctionDataset );
-        xdmfFunctionDataset->setStatistics( stats );
+        // This basically forces to load all data to calculate statistics
+        // (skipped when MDAL_LF_SkipStatistics is set; computed lazily later).
+        MDAL::setStatisticsIfRequired( xdmfFunctionDataset, loadFlags() );
         group->datasets.push_back( xdmfFunctionDataset );
       }
       else if (
@@ -534,9 +534,9 @@ MDAL::DatasetGroups MDAL::DriverXdmf::parseXdmfXml( )
               data.first,
               time
             );
-        // This basically forces to load all data to calculate statistics!
-        const MDAL::Statistics stats = MDAL::calculateStatistics( xdmfDataset );
-        xdmfDataset->setStatistics( stats );
+        // This basically forces to load all data to calculate statistics
+        // (skipped when MDAL_LF_SkipStatistics is set; computed lazily later).
+        MDAL::setStatisticsIfRequired( xdmfDataset, loadFlags() );
         group->datasets.push_back( xdmfDataset );
       }
       else
@@ -556,11 +556,21 @@ MDAL::DatasetGroups MDAL::DriverXdmf::parseXdmfXml( )
       throw MDAL::Error( MDAL_Status::Err_UnknownFormat, "Invalid group, missing timesteps" );
     }
 
-    const MDAL::Statistics stats = MDAL::calculateStatistics( grp );
-    grp->setStatistics( stats );
-    // verify the integrity of the dataset
-    if ( !std::isnan( stats.minimum ) )
+    // Verify the integrity of the dataset by computing the group's exact stats
+    // (cheap once each dataset has its own cached stats from the loop above).
+    // When MDAL_LF_SkipStatistics is set, we skip both the cache write AND the
+    // empty-group filter — the group is computed lazily on first access instead.
+    if ( loadFlags() & MDAL_LF_SkipStatistics )
+    {
       ret.emplace_back( std::move( grp ) );
+    }
+    else
+    {
+      const MDAL::Statistics stats = MDAL::calculateStatistics( grp );
+      grp->setStatistics( stats );
+      if ( !std::isnan( stats.minimum ) )
+        ret.emplace_back( std::move( grp ) );
+    }
   }
 
   return ret;

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -7,6 +7,7 @@
 #include <stddef.h>
 #include <limits>
 #include <assert.h>
+#include <cmath>
 #include <memory>
 
 #include "mdal.h"
@@ -188,6 +189,11 @@ int MDAL_DR_faceVerticesMaximumCount( MDAL_DriverH driver )
 
 MDAL_MeshH MDAL_LoadMesh( const char *uri )
 {
+  return MDAL_LoadMeshWithFlags( uri, 0 );
+}
+
+MDAL_MeshH MDAL_LoadMeshWithFlags( const char *uri, int flags )
+{
   if ( !uri )
   {
     MDAL::Log::error( MDAL_Status::Err_FileNotFound, "Mesh file is not valid (null)" );
@@ -200,10 +206,10 @@ MDAL_MeshH MDAL_LoadMesh( const char *uri )
 
   if ( !driverName.empty() )
   {
-    return static_cast< MDAL_MeshH >( MDAL::DriverManager::instance().load( driverName, meshFile, meshName ).release() );
+    return static_cast< MDAL_MeshH >( MDAL::DriverManager::instance().load( driverName, meshFile, meshName, flags ).release() );
   }
   else
-    return static_cast< MDAL_MeshH >( MDAL::DriverManager::instance().load( meshFile, meshName ).release() );
+    return static_cast< MDAL_MeshH >( MDAL::DriverManager::instance().load( meshFile, meshName, flags ).release() );
 }
 
 const char *MDAL_MeshNames( const char *uri )
@@ -939,6 +945,36 @@ void MDAL_G_minimumMaximum( MDAL_DatasetGroupH group, double *min, double *max )
 
   MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
   MDAL::Statistics stats = g->statistics();
+  if ( !stats.isComputed )
+  {
+    stats = MDAL::calculateStatistics( g );
+    g->setStatistics( stats );
+  }
+  *min = stats.minimum;
+  *max = stats.maximum;
+}
+
+void MDAL_G_minimumMaximumApprox( MDAL_DatasetGroupH group, int sampleCount, double *min, double *max )
+{
+  if ( !min || !max )
+  {
+    MDAL::Log::error( MDAL_Status::Err_InvalidData, "Passed pointers min or max are not valid (null)" );
+    return;
+  }
+
+  if ( !group )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleDataset, "Dataset is not valid (null)" );
+    *min = NODATA;
+    *max = NODATA;
+    return;
+  }
+
+  if ( sampleCount < 0 )
+    sampleCount = 0;
+
+  MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
+  MDAL::Statistics stats = MDAL::calculateStatisticsApprox( g, static_cast<size_t>( sampleCount ) );
   *min = stats.minimum;
   *max = stats.maximum;
 }
@@ -1406,6 +1442,11 @@ void MDAL_D_minimumMaximum( MDAL_DatasetH dataset, double *min, double *max )
 
   MDAL::Dataset *ds = static_cast< MDAL::Dataset * >( dataset );
   MDAL::Statistics stats = ds->statistics();
+  if ( !stats.isComputed )
+  {
+    stats = MDAL::calculateStatistics( ds );
+    ds->setStatistics( stats );
+  }
   *min = stats.minimum;
   *max = stats.maximum;
 }

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -944,11 +944,18 @@ void MDAL_G_minimumMaximum( MDAL_DatasetGroupH group, double *min, double *max )
   }
 
   MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
-  MDAL::Statistics stats = g->statistics();
-  if ( !stats.isComputed )
+  MDAL::Statistics stats;
+  try
   {
-    stats = MDAL::calculateStatistics( g );
-    g->setStatistics( stats );
+    stats = MDAL::ensureStatistics( g );
+  }
+  catch ( MDAL::Error &err )
+  {
+    MDAL::Log::error( err );
+  }
+  catch ( MDAL_Status status )
+  {
+    MDAL::Log::error( status, "Failed to compute group statistics" );
   }
   *min = stats.minimum;
   *max = stats.maximum;
@@ -974,7 +981,19 @@ void MDAL_G_minimumMaximumApprox( MDAL_DatasetGroupH group, int sampleCount, dou
     sampleCount = 0;
 
   MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
-  MDAL::Statistics stats = MDAL::calculateStatisticsApprox( g, static_cast<size_t>( sampleCount ) );
+  MDAL::Statistics stats;
+  try
+  {
+    stats = MDAL::calculateStatisticsApprox( g, static_cast<size_t>( sampleCount ) );
+  }
+  catch ( MDAL::Error &err )
+  {
+    MDAL::Log::error( err );
+  }
+  catch ( MDAL_Status status )
+  {
+    MDAL::Log::error( status, "Failed to compute approximate group statistics" );
+  }
   *min = stats.minimum;
   *max = stats.maximum;
 }
@@ -1441,11 +1460,18 @@ void MDAL_D_minimumMaximum( MDAL_DatasetH dataset, double *min, double *max )
   }
 
   MDAL::Dataset *ds = static_cast< MDAL::Dataset * >( dataset );
-  MDAL::Statistics stats = ds->statistics();
-  if ( !stats.isComputed )
+  MDAL::Statistics stats;
+  try
   {
-    stats = MDAL::calculateStatistics( ds );
-    ds->setStatistics( stats );
+    stats = MDAL::ensureStatistics( ds );
+  }
+  catch ( MDAL::Error &err )
+  {
+    MDAL::Log::error( err );
+  }
+  catch ( MDAL_Status status )
+  {
+    MDAL::Log::error( status, "Failed to compute dataset statistics" );
   }
   *min = stats.minimum;
   *max = stats.maximum;

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -7,7 +7,6 @@
 #include <stddef.h>
 #include <limits>
 #include <assert.h>
-#include <cmath>
 #include <memory>
 
 #include "mdal.h"

--- a/mdal/mdal.cpp
+++ b/mdal/mdal.cpp
@@ -401,6 +401,11 @@ int MDAL_M_faceVerticesMaximumCount( MDAL_MeshH mesh )
 
 void MDAL_M_LoadDatasets( MDAL_MeshH mesh, const char *datasetFile )
 {
+  MDAL_M_LoadDatasetsWithFlags( mesh, datasetFile, 0 );
+}
+
+void MDAL_M_LoadDatasetsWithFlags( MDAL_MeshH mesh, const char *datasetFile, int flags )
+{
   if ( !datasetFile )
   {
     MDAL::Log::error( MDAL_Status::Err_FileNotFound, "Dataset file is not valid (null)" );
@@ -415,8 +420,7 @@ void MDAL_M_LoadDatasets( MDAL_MeshH mesh, const char *datasetFile )
 
   MDAL::Mesh *m = static_cast< MDAL::Mesh * >( mesh );
 
-  std::string filename( datasetFile );
-  MDAL::DriverManager::instance().loadDatasets( m, datasetFile );
+  MDAL::DriverManager::instance().loadDatasets( m, datasetFile, flags );
 }
 
 int MDAL_M_metadataCount( MDAL_MeshH mesh )

--- a/mdal/mdal_data_model.cpp
+++ b/mdal/mdal_data_model.cpp
@@ -39,12 +39,15 @@ size_t MDAL::Dataset::activeData( size_t, size_t, int * )
 
 MDAL::Statistics MDAL::Dataset::statistics() const
 {
+  std::lock_guard<std::mutex> lock( mStatisticsMutex );
   return mStatistics;
 }
 
 void MDAL::Dataset::setStatistics( const MDAL::Statistics &statistics )
 {
+  std::lock_guard<std::mutex> lock( mStatisticsMutex );
   mStatistics = statistics;
+  mStatistics.isComputed = true;
 }
 
 MDAL::DatasetGroup *MDAL::Dataset::group() const
@@ -220,12 +223,15 @@ void MDAL::DatasetGroup::replaceUri( std::string uri )
 
 MDAL::Statistics MDAL::DatasetGroup::statistics() const
 {
+  std::lock_guard<std::mutex> lock( mStatisticsMutex );
   return mStatistics;
 }
 
 void MDAL::DatasetGroup::setStatistics( const Statistics &statistics )
 {
+  std::lock_guard<std::mutex> lock( mStatisticsMutex );
   mStatistics = statistics;
+  mStatistics.isComputed = true;
 }
 
 MDAL::DateTime MDAL::DatasetGroup::referenceTime() const

--- a/mdal/mdal_data_model.cpp
+++ b/mdal/mdal_data_model.cpp
@@ -48,6 +48,10 @@ void MDAL::Dataset::setStatistics( const MDAL::Statistics &statistics )
   mStatistics.isComputed = true;
 }
 
+void MDAL::Dataset::releaseLoadedData()
+{
+}
+
 MDAL::DatasetGroup *MDAL::Dataset::group() const
 {
   return mParent;

--- a/mdal/mdal_data_model.cpp
+++ b/mdal/mdal_data_model.cpp
@@ -39,13 +39,11 @@ size_t MDAL::Dataset::activeData( size_t, size_t, int * )
 
 MDAL::Statistics MDAL::Dataset::statistics() const
 {
-  std::lock_guard<std::mutex> lock( mStatisticsMutex );
   return mStatistics;
 }
 
 void MDAL::Dataset::setStatistics( const MDAL::Statistics &statistics )
 {
-  std::lock_guard<std::mutex> lock( mStatisticsMutex );
   mStatistics = statistics;
   mStatistics.isComputed = true;
 }
@@ -223,13 +221,11 @@ void MDAL::DatasetGroup::replaceUri( std::string uri )
 
 MDAL::Statistics MDAL::DatasetGroup::statistics() const
 {
-  std::lock_guard<std::mutex> lock( mStatisticsMutex );
   return mStatistics;
 }
 
 void MDAL::DatasetGroup::setStatistics( const Statistics &statistics )
 {
-  std::lock_guard<std::mutex> lock( mStatisticsMutex );
   mStatistics = statistics;
   mStatistics.isComputed = true;
 }

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <memory>
 #include <map>
+#include <mutex>
 #include <string>
 #include <limits>
 #include "mdal.h"
@@ -35,6 +36,7 @@ namespace MDAL
   {
     double minimum = std::numeric_limits<double>::quiet_NaN();
     double maximum = std::numeric_limits<double>::quiet_NaN();
+    bool isComputed = false;
   } Statistics;
 
   typedef std::vector< std::pair< std::string, std::string > > Metadata;
@@ -91,6 +93,7 @@ namespace MDAL
       bool mSupportsActiveFlag = false;
       DatasetGroup *mParent = nullptr;
       Statistics mStatistics;
+      mutable std::mutex mStatisticsMutex;
   };
 
   class Dataset2D: public Dataset
@@ -200,6 +203,7 @@ namespace MDAL
       MDAL_DataLocation mDataLocation = MDAL_DataLocation::DataOnVertices;
       std::string mUri; // file/uri from where it came
       Statistics mStatistics;
+      mutable std::mutex mStatisticsMutex;
       DateTime mReferenceTime;
   };
 

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -73,6 +73,10 @@ namespace MDAL
       Statistics statistics() const;
       void setStatistics( const Statistics &statistics );
 
+      //! Releases values cached in memory by an on-demand read of the dataset
+      //! (no-op for datasets whose values permanently live in memory)
+      virtual void releaseLoadedData();
+
       bool isValid() const;
 
       DatasetGroup *group() const;

--- a/mdal/mdal_data_model.hpp
+++ b/mdal/mdal_data_model.hpp
@@ -10,7 +10,6 @@
 #include <vector>
 #include <memory>
 #include <map>
-#include <mutex>
 #include <string>
 #include <limits>
 #include "mdal.h"
@@ -93,7 +92,6 @@ namespace MDAL
       bool mSupportsActiveFlag = false;
       DatasetGroup *mParent = nullptr;
       Statistics mStatistics;
-      mutable std::mutex mStatisticsMutex;
   };
 
   class Dataset2D: public Dataset
@@ -203,7 +201,6 @@ namespace MDAL
       MDAL_DataLocation mDataLocation = MDAL_DataLocation::DataOnVertices;
       std::string mUri; // file/uri from where it came
       Statistics mStatistics;
-      mutable std::mutex mStatisticsMutex;
       DateTime mReferenceTime;
   };
 

--- a/mdal/mdal_driver_manager.cpp
+++ b/mdal/mdal_driver_manager.cpp
@@ -84,7 +84,7 @@ std::string MDAL::DriverManager::getUris( const std::string &file, const std::st
   return std::string();
 }
 
-std::unique_ptr<MDAL::Mesh> MDAL::DriverManager::load( const std::string &meshFile, const std::string &meshName ) const
+std::unique_ptr<MDAL::Mesh> MDAL::DriverManager::load( const std::string &meshFile, const std::string &meshName, int loadFlags ) const
 {
   std::unique_ptr<MDAL::Mesh> mesh;
 
@@ -100,6 +100,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverManager::load( const std::string &meshFi
          driver->canReadMesh( meshFile ) )
     {
       std::unique_ptr<MDAL::Driver> drv( driver->create() );
+      drv->setLoadFlags( loadFlags );
 
       mesh = drv->load( meshFile, meshName );
       if ( mesh ) // stop if he have the mesh
@@ -116,7 +117,8 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverManager::load( const std::string &meshFi
 std::unique_ptr<MDAL::Mesh> MDAL::DriverManager::load(
   const std::string &driverName,
   const std::string &meshFile,
-  const std::string &meshName ) const
+  const std::string &meshName,
+  int loadFlags ) const
 {
   std::unique_ptr<MDAL::Mesh> mesh;
 
@@ -135,6 +137,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverManager::load(
   }
 
   std::unique_ptr<Driver> drv( requestedDriver->create() );
+  drv->setLoadFlags( loadFlags );
   mesh = drv->load( meshFile, meshName );
 
   return mesh;

--- a/mdal/mdal_driver_manager.cpp
+++ b/mdal/mdal_driver_manager.cpp
@@ -143,7 +143,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::DriverManager::load(
   return mesh;
 }
 
-void MDAL::DriverManager::loadDatasets( Mesh *mesh, const std::string &datasetFile ) const
+void MDAL::DriverManager::loadDatasets( Mesh *mesh, const std::string &datasetFile, int loadFlags ) const
 {
   if ( !MDAL::fileExists( datasetFile ) )
   {
@@ -163,6 +163,7 @@ void MDAL::DriverManager::loadDatasets( Mesh *mesh, const std::string &datasetFi
          driver->canReadDatasets( datasetFile ) )
     {
       std::unique_ptr<Driver> drv( driver->create() );
+      drv->setLoadFlags( loadFlags );
       drv->load( datasetFile, mesh );
       return;
     }

--- a/mdal/mdal_driver_manager.hpp
+++ b/mdal/mdal_driver_manager.hpp
@@ -32,10 +32,11 @@ namespace MDAL
 
       std::string getUris( const std::string &file, const std::string &driverName = "" ) const;
 
-      std::unique_ptr< Mesh > load( const std::string &meshFile, const std::string &meshName ) const;
+      std::unique_ptr< Mesh > load( const std::string &meshFile, const std::string &meshName, int loadFlags = 0 ) const;
       std::unique_ptr< Mesh > load( const std::string &driverName,
                                     const std::string &meshFile,
-                                    const std::string &meshName ) const;
+                                    const std::string &meshName,
+                                    int loadFlags = 0 ) const;
       void loadDatasets( Mesh *mesh, const std::string &datasetFile ) const;
 
       void save( Mesh *mesh, const std::string &uri ) const;

--- a/mdal/mdal_driver_manager.hpp
+++ b/mdal/mdal_driver_manager.hpp
@@ -32,11 +32,11 @@ namespace MDAL
 
       std::string getUris( const std::string &file, const std::string &driverName = "" ) const;
 
-      std::unique_ptr< Mesh > load( const std::string &meshFile, const std::string &meshName, int loadFlags = 0 ) const;
+      std::unique_ptr< Mesh > load( const std::string &meshFile, const std::string &meshName, int loadFlags ) const;
       std::unique_ptr< Mesh > load( const std::string &driverName,
                                     const std::string &meshFile,
                                     const std::string &meshName,
-                                    int loadFlags = 0 ) const;
+                                    int loadFlags ) const;
       void loadDatasets( Mesh *mesh, const std::string &datasetFile ) const;
 
       void save( Mesh *mesh, const std::string &uri ) const;

--- a/mdal/mdal_driver_manager.hpp
+++ b/mdal/mdal_driver_manager.hpp
@@ -37,7 +37,7 @@ namespace MDAL
                                     const std::string &meshFile,
                                     const std::string &meshName,
                                     int loadFlags ) const;
-      void loadDatasets( Mesh *mesh, const std::string &datasetFile ) const;
+      void loadDatasets( Mesh *mesh, const std::string &datasetFile, int loadFlags ) const;
 
       void save( Mesh *mesh, const std::string &uri ) const;
 

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -654,46 +654,57 @@ MDAL::Statistics MDAL::calculateStatistics( DatasetGroup *grp )
     return ret;
 
   for ( std::shared_ptr<Dataset> &ds : grp->datasets )
-  {
-    MDAL::Statistics dsStats = ds->statistics();
-    if ( !dsStats.isComputed )
-    {
-      dsStats = calculateStatistics( ds );
-      ds->setStatistics( dsStats );
-    }
-    combineStatistics( ret, dsStats );
-  }
+    combineStatistics( ret, ensureStatistics( ds.get() ) );
   ret.isComputed = true;
   return ret;
 }
 
+MDAL::Statistics MDAL::ensureStatistics( Dataset *dataset )
+{
+  Statistics stats = dataset->statistics();
+  if ( !stats.isComputed )
+  {
+    stats = calculateStatistics( dataset );
+    dataset->setStatistics( stats );
+    dataset->releaseLoadedData();
+  }
+  return stats;
+}
+
+MDAL::Statistics MDAL::ensureStatistics( DatasetGroup *group )
+{
+  Statistics stats = group->statistics();
+  if ( !stats.isComputed )
+  {
+    stats = calculateStatistics( group );
+    if ( !group->isInEditMode() )
+      group->setStatistics( stats );
+  }
+  return stats;
+}
+
 MDAL::Statistics MDAL::calculateStatisticsApprox( DatasetGroup *grp, size_t sampleCount )
 {
-  Statistics ret;
   if ( !grp )
-    return ret;
+    return Statistics();
 
   const size_t n = grp->datasets.size();
   if ( sampleCount == 0 || sampleCount >= n )
-    return calculateStatistics( grp );
+    return ensureStatistics( grp );
 
-  size_t lastIdx = std::numeric_limits<size_t>::max();
+  Statistics ret;
   for ( size_t i = 0; i < sampleCount; ++i )
   {
-    const size_t idx = ( sampleCount == 1 ) ? 0 : ( i * ( n - 1 ) ) / ( sampleCount - 1 );
-    if ( idx == lastIdx )
-      continue;
-
-    std::shared_ptr<Dataset> ds = grp->datasets[idx];
-    MDAL::Statistics dsStats = ds->statistics();
-    if ( !dsStats.isComputed )
-    {
-      dsStats = calculateStatistics( ds );
-      ds->setStatistics( dsStats );
-    }
-    combineStatistics( ret, dsStats );
-    lastIdx = idx;
+    // evenly spaced, endpoints included; indices are strictly increasing since sampleCount < n
+    const size_t idx = ( sampleCount == 1 ) ? ( n - 1 ) / 2 : ( i * ( n - 1 ) ) / ( sampleCount - 1 );
+    combineStatistics( ret, ensureStatistics( grp->datasets[idx].get() ) );
   }
+
+  // a sample without any valid value (e.g. domain dry at the sampled times)
+  // would be indistinguishable from an error: fall back to the exact range
+  if ( std::isnan( ret.minimum ) )
+    return ensureStatistics( grp );
+
   return ret;
 }
 

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -638,6 +638,7 @@ MDAL::Statistics _calculateStatistics( const std::vector<double> &values, size_t
 
   ret.minimum = min;
   ret.maximum = max;
+  ret.isComputed = true;
   return ret;
 }
 
@@ -655,12 +656,76 @@ MDAL::Statistics MDAL::calculateStatistics( DatasetGroup *grp )
   for ( std::shared_ptr<Dataset> &ds : grp->datasets )
   {
     MDAL::Statistics dsStats = ds->statistics();
+    if ( !dsStats.isComputed )
+    {
+      dsStats = calculateStatistics( ds );
+      ds->setStatistics( dsStats );
+    }
     combineStatistics( ret, dsStats );
+  }
+  ret.isComputed = true;
+  return ret;
+}
+
+MDAL::Statistics MDAL::calculateStatisticsApprox( DatasetGroup *grp, size_t sampleCount )
+{
+  Statistics ret;
+  if ( !grp )
+    return ret;
+
+  const size_t n = grp->datasets.size();
+  if ( sampleCount == 0 || sampleCount >= n )
+    return calculateStatistics( grp );
+
+  size_t lastIdx = std::numeric_limits<size_t>::max();
+  for ( size_t i = 0; i < sampleCount; ++i )
+  {
+    const size_t idx = ( sampleCount == 1 ) ? 0 : ( i * ( n - 1 ) ) / ( sampleCount - 1 );
+    if ( idx == lastIdx )
+      continue;
+
+    std::shared_ptr<Dataset> ds = grp->datasets[idx];
+    MDAL::Statistics dsStats = ds->statistics();
+    if ( !dsStats.isComputed )
+    {
+      dsStats = calculateStatistics( ds );
+      ds->setStatistics( dsStats );
+    }
+    combineStatistics( ret, dsStats );
+    lastIdx = idx;
   }
   return ret;
 }
 
+void MDAL::setStatisticsIfRequired( const std::shared_ptr<Dataset> &dataset, int loadFlags )
+{
+  if ( !dataset )
+    return;
+  if ( loadFlags & MDAL_LF_SkipStatistics )
+    return;
+  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
+}
+
+void MDAL::setStatisticsIfRequired( const std::shared_ptr<DatasetGroup> &group, int loadFlags )
+{
+  setStatisticsIfRequired( group.get(), loadFlags );
+}
+
+void MDAL::setStatisticsIfRequired( DatasetGroup *group, int loadFlags )
+{
+  if ( !group )
+    return;
+  if ( loadFlags & MDAL_LF_SkipStatistics )
+    return;
+  group->setStatistics( MDAL::calculateStatistics( group ) );
+}
+
 MDAL::Statistics MDAL::calculateStatistics( std::shared_ptr<Dataset> dataset )
+{
+  return calculateStatistics( dataset.get() );
+}
+
+MDAL::Statistics MDAL::calculateStatistics( Dataset *dataset )
 {
   Statistics ret;
   if ( !dataset )
@@ -706,13 +771,14 @@ MDAL::Statistics MDAL::calculateStatistics( std::shared_ptr<Dataset> dataset )
         dataset->activeData( i, bufLen, activeBuffer.data() );
     }
     if ( valsRead == 0 )
-      return ret;
+      break;
 
     MDAL::Statistics dsStats = _calculateStatistics( buffer, valsRead, isVector, activeBuffer );
     combineStatistics( ret, dsStats );
     i += valsRead;
   }
 
+  ret.isComputed = true;
   return ret;
 }
 

--- a/mdal/mdal_utils.cpp
+++ b/mdal/mdal_utils.cpp
@@ -638,7 +638,6 @@ MDAL::Statistics _calculateStatistics( const std::vector<double> &values, size_t
 
   ret.minimum = min;
   ret.maximum = max;
-  ret.isComputed = true;
   return ret;
 }
 
@@ -653,9 +652,9 @@ MDAL::Statistics MDAL::calculateStatistics( DatasetGroup *grp )
   if ( !grp )
     return ret;
 
+  // note: isComputed is a property of the caches only, set by setStatistics()
   for ( std::shared_ptr<Dataset> &ds : grp->datasets )
     combineStatistics( ret, ensureStatistics( ds.get() ) );
-  ret.isComputed = true;
   return ret;
 }
 
@@ -706,29 +705,6 @@ MDAL::Statistics MDAL::calculateStatisticsApprox( DatasetGroup *grp, size_t samp
     return ensureStatistics( grp );
 
   return ret;
-}
-
-void MDAL::setStatisticsIfRequired( const std::shared_ptr<Dataset> &dataset, int loadFlags )
-{
-  if ( !dataset )
-    return;
-  if ( loadFlags & MDAL_LF_SkipStatistics )
-    return;
-  dataset->setStatistics( MDAL::calculateStatistics( dataset ) );
-}
-
-void MDAL::setStatisticsIfRequired( const std::shared_ptr<DatasetGroup> &group, int loadFlags )
-{
-  setStatisticsIfRequired( group.get(), loadFlags );
-}
-
-void MDAL::setStatisticsIfRequired( DatasetGroup *group, int loadFlags )
-{
-  if ( !group )
-    return;
-  if ( loadFlags & MDAL_LF_SkipStatistics )
-    return;
-  group->setStatistics( MDAL::calculateStatistics( group ) );
 }
 
 MDAL::Statistics MDAL::calculateStatistics( std::shared_ptr<Dataset> dataset )
@@ -782,14 +758,13 @@ MDAL::Statistics MDAL::calculateStatistics( Dataset *dataset )
         dataset->activeData( i, bufLen, activeBuffer.data() );
     }
     if ( valsRead == 0 )
-      break;
+      return ret;
 
     MDAL::Statistics dsStats = _calculateStatistics( buffer, valsRead, isVector, activeBuffer );
     combineStatistics( ret, dsStats );
     i += valsRead;
   }
 
-  ret.isComputed = true;
   return ret;
 }
 

--- a/mdal/mdal_utils.hpp
+++ b/mdal/mdal_utils.hpp
@@ -165,8 +165,23 @@ namespace MDAL
   Statistics calculateStatistics( std::shared_ptr<DatasetGroup> grp );
   Statistics calculateStatistics( DatasetGroup *grp );
 
+  //! Calculates approximate statistics for dataset group from a sample of
+  //! \a sampleCount evenly-spaced datasets (endpoints included). When
+  //! \a sampleCount is 0 or greater or equal to the dataset count, falls
+  //! back to the exact statistics computation. If a sampled dataset has no cached statistics
+  //! yet (e.g. loaded with MDAL_LF_SkipStatistics) they are computed on the
+  //! fly and cached on the dataset, so a later exact call benefits from them.
+  Statistics calculateStatisticsApprox( DatasetGroup *grp, size_t sampleCount );
+
   //! Calculates statistics for dataset
   Statistics calculateStatistics( std::shared_ptr<Dataset> dataset );
+  Statistics calculateStatistics( Dataset *dataset );
+
+  //! Sets stats unless loadFlags has MDAL_LF_SkipStatistics. Drivers should
+  //! use this in place of `target->setStatistics( calculateStatistics(target) )`.
+  void setStatisticsIfRequired( const std::shared_ptr<Dataset> &dataset, int loadFlags );
+  void setStatisticsIfRequired( const std::shared_ptr<DatasetGroup> &group, int loadFlags );
+  void setStatisticsIfRequired( DatasetGroup *group, int loadFlags );
 
   // mesh & datasets
   //! Adds bed elevatiom dataset group to mesh

--- a/mdal/mdal_utils.hpp
+++ b/mdal/mdal_utils.hpp
@@ -177,6 +177,13 @@ namespace MDAL
   Statistics calculateStatistics( std::shared_ptr<Dataset> dataset );
   Statistics calculateStatistics( Dataset *dataset );
 
+  //! Returns the cached statistics, computing, caching and releasing the
+  //! lazily loaded values on first access
+  Statistics ensureStatistics( Dataset *dataset );
+  //! Group overload; the result is not cached while the group is in edit mode
+  //! so that datasets added later are taken into account
+  Statistics ensureStatistics( DatasetGroup *group );
+
   //! Sets stats unless loadFlags has MDAL_LF_SkipStatistics. Drivers should
   //! use this in place of `target->setStatistics( calculateStatistics(target) )`.
   void setStatisticsIfRequired( const std::shared_ptr<Dataset> &dataset, int loadFlags );

--- a/mdal/mdal_utils.hpp
+++ b/mdal/mdal_utils.hpp
@@ -184,11 +184,16 @@ namespace MDAL
   //! so that datasets added later are taken into account
   Statistics ensureStatistics( DatasetGroup *group );
 
-  //! Sets stats unless loadFlags has MDAL_LF_SkipStatistics. Drivers should
-  //! use this in place of `target->setStatistics( calculateStatistics(target) )`.
-  void setStatisticsIfRequired( const std::shared_ptr<Dataset> &dataset, int loadFlags );
-  void setStatisticsIfRequired( const std::shared_ptr<DatasetGroup> &group, int loadFlags );
-  void setStatisticsIfRequired( DatasetGroup *group, int loadFlags );
+  //! Computes and stores statistics for \a target (raw or shared pointer to
+  //! a Dataset or DatasetGroup) unless loadFlags has MDAL_LF_SkipStatistics.
+  //! Drivers should use this in place of
+  //! `target->setStatistics( calculateStatistics( target ) )`.
+  template <typename T>
+  void setStatisticsIfRequired( const T &target, int loadFlags )
+  {
+    if ( target && !( loadFlags & MDAL_LF_SkipStatistics ) )
+      target->setStatistics( calculateStatistics( &*target ) );
+  }
 
   // mesh & datasets
   //! Adds bed elevatiom dataset group to mesh

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ SET(TESTS
     test_2dm.cpp
     test_xms_tin.cpp
     test_api.cpp
+    test_approx_statistics.cpp
     test_ascii_dat.cpp
     test_binary_dat.cpp
     test_selafin.cpp

--- a/tests/test_approx_statistics.cpp
+++ b/tests/test_approx_statistics.cpp
@@ -1,0 +1,221 @@
+/*
+ MDAL - Mesh Data Abstraction Library (MIT License)
+ Copyright (C) 2026 Lutra Consulting Limited
+*/
+#include "gtest/gtest.h"
+#include <string>
+#include <vector>
+#include <cmath>
+#include <limits>
+
+//mdal
+#include "mdal.h"
+#include "mdal_testutils.hpp"
+
+namespace
+{
+  // Build a multi-timestep scalar group with `nDatasets` datasets persisted
+  // to a SELAFIN file. The dataset at `peakIndex` is given an outlier value
+  // so that approximate sampling that misses this index will not capture
+  // the global minimum/maximum.
+  MDAL_MeshH buildMultiTimestepMesh( const std::string &savedFile,
+                                     int nDatasets,
+                                     int peakIndex,
+                                     double peakValue )
+  {
+    std::string sourceFile = test_file( "/slf/example.slf" );
+    MDAL_MeshH sourceMesh = MDAL_LoadMesh( sourceFile.c_str() );
+    EXPECT_NE( sourceMesh, nullptr );
+    MDAL_SaveMesh( sourceMesh, savedFile.c_str(), "SELAFIN" );
+    EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::None );
+    MDAL_CloseMesh( sourceMesh );
+
+    MDAL_MeshH mesh = MDAL_LoadMesh( savedFile.c_str() );
+    EXPECT_NE( mesh, nullptr );
+
+    MDAL_DriverH driver = MDAL_driverFromName( "SELAFIN" );
+    MDAL_DatasetGroupH g = MDAL_M_addDatasetGroup( mesh,
+                           "TestGroup",
+                           DataOnVertices,
+                           true /*scalar*/,
+                           driver,
+                           savedFile.c_str() );
+    EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::None );
+
+    const size_t v_count = MDAL_M_vertexCount( mesh );
+    for ( int i = 0; i < nDatasets; ++i )
+    {
+      std::vector<double> values( v_count, static_cast<double>( i ) );
+      if ( i == peakIndex )
+      {
+        // Replace the first value with the outlier so the dataset's min or max
+        // becomes the outlier (depending on sign).
+        values[0] = peakValue;
+      }
+      MDAL_G_addDataset( g, static_cast<double>( i ), values.data(), nullptr );
+      EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::None );
+    }
+    MDAL_G_closeEditMode( g );
+    EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::None );
+    return mesh;
+  }
+}
+
+TEST( MeshApproxStatisticsTest, SampleCountZeroEqualsExact )
+{
+  std::string file = tmp_file( "/approx_stats_sc0.slf" );
+  MDAL_MeshH m = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  ASSERT_NE( m, nullptr );
+
+  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  ASSERT_NE( g, nullptr );
+
+  double minE = NAN, maxE = NAN, minA = NAN, maxA = NAN;
+  MDAL_G_minimumMaximum( g, &minE, &maxE );
+  MDAL_G_minimumMaximumApprox( g, 0, &minA, &maxA );
+
+  EXPECT_DOUBLE_EQ( minE, minA );
+  EXPECT_DOUBLE_EQ( maxE, maxA );
+
+  MDAL_CloseMesh( m );
+}
+
+TEST( MeshApproxStatisticsTest, SampleCountAboveOrEqualToDatasetCountEqualsExact )
+{
+  std::string file = tmp_file( "/approx_stats_full.slf" );
+  MDAL_MeshH m = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  ASSERT_NE( m, nullptr );
+
+  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  ASSERT_NE( g, nullptr );
+
+  double minE = NAN, maxE = NAN, minA = NAN, maxA = NAN;
+  MDAL_G_minimumMaximum( g, &minE, &maxE );
+  MDAL_G_minimumMaximumApprox( g, 10, &minA, &maxA );
+
+  EXPECT_DOUBLE_EQ( minE, minA );
+  EXPECT_DOUBLE_EQ( maxE, maxA );
+
+  // The global maximum must be the outlier we placed at index 5
+  EXPECT_DOUBLE_EQ( 1000.0, maxE );
+
+  MDAL_CloseMesh( m );
+}
+
+TEST( MeshApproxStatisticsTest, SampleCountThreeMissesMiddleOutlier )
+{
+  // For n=10 and sampleCount=3 the chosen indices are {0, 4, 9}
+  // — the outlier at index 5 must be missed.
+  std::string file = tmp_file( "/approx_stats_sc3.slf" );
+  MDAL_MeshH m = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  ASSERT_NE( m, nullptr );
+
+  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  ASSERT_NE( g, nullptr );
+
+  double minE = NAN, maxE = NAN, minA = NAN, maxA = NAN;
+  MDAL_G_minimumMaximum( g, &minE, &maxE );
+  MDAL_G_minimumMaximumApprox( g, 3, &minA, &maxA );
+
+  EXPECT_DOUBLE_EQ( 1000.0, maxE );      // exact captures the outlier
+  EXPECT_LT( maxA, 1000.0 );             // approximate misses it
+  EXPECT_LE( minE, minA );               // approximate range is contained in exact range
+  EXPECT_GE( maxE, maxA );
+
+  MDAL_CloseMesh( m );
+}
+
+TEST( MeshApproxStatisticsTest, ExactCacheUntouchedAfterApproximate )
+{
+  std::string file = tmp_file( "/approx_stats_cache.slf" );
+  MDAL_MeshH m = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  ASSERT_NE( m, nullptr );
+
+  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  ASSERT_NE( g, nullptr );
+
+  // Call approximate first
+  double minA = NAN, maxA = NAN;
+  MDAL_G_minimumMaximumApprox( g, 3, &minA, &maxA );
+  EXPECT_LT( maxA, 1000.0 );
+
+  // Exact must still return the true range
+  double minE = NAN, maxE = NAN;
+  MDAL_G_minimumMaximum( g, &minE, &maxE );
+  EXPECT_DOUBLE_EQ( 1000.0, maxE );
+
+  MDAL_CloseMesh( m );
+}
+
+TEST( MeshLoadFlagsTest, SkipStatisticsThenLazyExact )
+{
+  // Build a multi-timestep selafin first (writes through the addDataset edit
+  // mode path, which always computes stats — eager path is unaffected).
+  std::string file = tmp_file( "/skipstats_eager.slf" );
+  MDAL_MeshH eager = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  ASSERT_NE( eager, nullptr );
+  MDAL_CloseMesh( eager );
+
+  // Reload with MDAL_LF_SkipStatistics: the SELAFIN driver must NOT compute
+  // per-dataset stats during load.
+  MDAL_MeshH m = MDAL_LoadMeshWithFlags( file.c_str(), MDAL_LF_SkipStatistics );
+  ASSERT_NE( m, nullptr );
+
+  // Expect at least one dataset group.
+  ASSERT_GE( MDAL_M_datasetGroupCount( m ), 1 );
+  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  ASSERT_NE( g, nullptr );
+
+  // Approximate min/max computes only on a sample of timesteps; result must
+  // still be contained within the (later-computed) exact range and the
+  // outlier dataset (idx 5) is missed when sampleCount=3.
+  double minA = NAN, maxA = NAN;
+  MDAL_G_minimumMaximumApprox( g, 3, &minA, &maxA );
+  EXPECT_FALSE( std::isnan( maxA ) );
+  EXPECT_LT( maxA, 1000.0 );
+
+  // Exact (lazy) computes on first access and caches: must return 1000.
+  double minE = NAN, maxE = NAN;
+  MDAL_G_minimumMaximum( g, &minE, &maxE );
+  EXPECT_DOUBLE_EQ( 1000.0, maxE );
+
+  // A second exact call returns the cached value (sanity).
+  double minE2 = NAN, maxE2 = NAN;
+  MDAL_G_minimumMaximum( g, &minE2, &maxE2 );
+  EXPECT_DOUBLE_EQ( minE, minE2 );
+  EXPECT_DOUBLE_EQ( maxE, maxE2 );
+
+  MDAL_CloseMesh( m );
+}
+
+TEST( MeshLoadFlagsTest, NoSkipFlagPreservesEagerBehavior )
+{
+  // Without the flag, MDAL_LoadMesh and MDAL_LoadMeshWithFlags(uri, 0) must
+  // compute stats eagerly so the first MDAL_G_minimumMaximum call is a
+  // no-op cache read.
+  std::string file = tmp_file( "/skipstats_default.slf" );
+  MDAL_MeshH eager = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  ASSERT_NE( eager, nullptr );
+  MDAL_CloseMesh( eager );
+
+  MDAL_MeshH m = MDAL_LoadMeshWithFlags( file.c_str(), 0 );
+  ASSERT_NE( m, nullptr );
+
+  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  ASSERT_NE( g, nullptr );
+
+  double min = NAN, max = NAN;
+  MDAL_G_minimumMaximum( g, &min, &max );
+  EXPECT_DOUBLE_EQ( 1000.0, max );
+
+  MDAL_CloseMesh( m );
+}
+
+int main( int argc, char **argv )
+{
+  testing::InitGoogleTest( &argc, argv );
+  init_test();
+  int ret = RUN_ALL_TESTS();
+  finalize_test();
+  return ret;
+}

--- a/tests/test_approx_statistics.cpp
+++ b/tests/test_approx_statistics.cpp
@@ -14,14 +14,16 @@
 
 namespace
 {
-  // Build a multi-timestep scalar group with `nDatasets` datasets persisted
-  // to a SELAFIN file. The dataset at `peakIndex` is given an outlier value
-  // so that approximate sampling that misses this index will not capture
-  // the global minimum/maximum.
-  MDAL_MeshH buildMultiTimestepMesh( const std::string &savedFile,
-                                     int nDatasets,
-                                     int peakIndex,
-                                     double peakValue )
+  const int kDatasetCount = 10;
+  const int kPeakIndex = 5;
+  const double kPeakValue = 1000.0;
+
+  // Build a multi-timestep scalar group persisted to a SELAFIN file:
+  // kDatasetCount datasets where dataset i holds the constant value i,
+  // except dataset kPeakIndex whose first value is the outlier kPeakValue.
+  // Approximate sampling that misses kPeakIndex will not capture the
+  // global maximum.
+  MDAL_MeshH buildMultiTimestepMesh( const std::string &savedFile )
   {
     std::string sourceFile = test_file( "/slf/example.slf" );
     MDAL_MeshH sourceMesh = MDAL_LoadMesh( sourceFile.c_str() );
@@ -43,15 +45,11 @@ namespace
     EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::None );
 
     const size_t v_count = MDAL_M_vertexCount( mesh );
-    for ( int i = 0; i < nDatasets; ++i )
+    for ( int i = 0; i < kDatasetCount; ++i )
     {
       std::vector<double> values( v_count, static_cast<double>( i ) );
-      if ( i == peakIndex )
-      {
-        // Replace the first value with the outlier so the dataset's min or max
-        // becomes the outlier (depending on sign).
-        values[0] = peakValue;
-      }
+      if ( i == kPeakIndex )
+        values[0] = kPeakValue;
       MDAL_G_addDataset( g, static_cast<double>( i ), values.data(), nullptr );
       EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::None );
     }
@@ -59,45 +57,53 @@ namespace
     EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::None );
     return mesh;
   }
+
+  MDAL_DatasetGroupH lastGroup( MDAL_MeshH mesh )
+  {
+    return MDAL_M_datasetGroup( mesh, MDAL_M_datasetGroupCount( mesh ) - 1 );
+  }
 }
 
-TEST( MeshApproxStatisticsTest, SampleCountZeroEqualsExact )
+TEST( MeshApproxStatisticsTest, ExactFallbacksEqualExact )
 {
-  std::string file = tmp_file( "/approx_stats_sc0.slf" );
-  MDAL_MeshH m = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  std::string file = tmp_file( "/approx_stats_fallback.slf" );
+  MDAL_MeshH m = buildMultiTimestepMesh( file );
   ASSERT_NE( m, nullptr );
 
-  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  MDAL_DatasetGroupH g = lastGroup( m );
   ASSERT_NE( g, nullptr );
 
-  double minE = NAN, maxE = NAN, minA = NAN, maxA = NAN;
+  double minE = NAN, maxE = NAN;
   MDAL_G_minimumMaximum( g, &minE, &maxE );
-  MDAL_G_minimumMaximumApprox( g, 0, &minA, &maxA );
+  EXPECT_DOUBLE_EQ( kPeakValue, maxE );
 
-  EXPECT_DOUBLE_EQ( minE, minA );
-  EXPECT_DOUBLE_EQ( maxE, maxA );
+  // sampleCount 0, negative, == count and > count all fall back to exact
+  for ( int sampleCount : { 0, -5, kDatasetCount, 999 } )
+  {
+    double minA = NAN, maxA = NAN;
+    MDAL_G_minimumMaximumApprox( g, sampleCount, &minA, &maxA );
+    EXPECT_DOUBLE_EQ( minE, minA ) << "sampleCount=" << sampleCount;
+    EXPECT_DOUBLE_EQ( maxE, maxA ) << "sampleCount=" << sampleCount;
+  }
 
   MDAL_CloseMesh( m );
 }
 
-TEST( MeshApproxStatisticsTest, SampleCountAboveOrEqualToDatasetCountEqualsExact )
+TEST( MeshApproxStatisticsTest, SampleCountOneUsesMiddleDataset )
 {
-  std::string file = tmp_file( "/approx_stats_full.slf" );
-  MDAL_MeshH m = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  // For n=10 and sampleCount=1 the middle dataset (index 4) is sampled:
+  // constant value 4, and the outlier at index 5 is missed.
+  std::string file = tmp_file( "/approx_stats_sc1.slf" );
+  MDAL_MeshH m = buildMultiTimestepMesh( file );
   ASSERT_NE( m, nullptr );
 
-  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  MDAL_DatasetGroupH g = lastGroup( m );
   ASSERT_NE( g, nullptr );
 
-  double minE = NAN, maxE = NAN, minA = NAN, maxA = NAN;
-  MDAL_G_minimumMaximum( g, &minE, &maxE );
-  MDAL_G_minimumMaximumApprox( g, 10, &minA, &maxA );
-
-  EXPECT_DOUBLE_EQ( minE, minA );
-  EXPECT_DOUBLE_EQ( maxE, maxA );
-
-  // The global maximum must be the outlier we placed at index 5
-  EXPECT_DOUBLE_EQ( 1000.0, maxE );
+  double minA = NAN, maxA = NAN;
+  MDAL_G_minimumMaximumApprox( g, 1, &minA, &maxA );
+  EXPECT_DOUBLE_EQ( 4.0, minA );
+  EXPECT_DOUBLE_EQ( 4.0, maxA );
 
   MDAL_CloseMesh( m );
 }
@@ -107,18 +113,18 @@ TEST( MeshApproxStatisticsTest, SampleCountThreeMissesMiddleOutlier )
   // For n=10 and sampleCount=3 the chosen indices are {0, 4, 9}
   // — the outlier at index 5 must be missed.
   std::string file = tmp_file( "/approx_stats_sc3.slf" );
-  MDAL_MeshH m = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  MDAL_MeshH m = buildMultiTimestepMesh( file );
   ASSERT_NE( m, nullptr );
 
-  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  MDAL_DatasetGroupH g = lastGroup( m );
   ASSERT_NE( g, nullptr );
 
   double minE = NAN, maxE = NAN, minA = NAN, maxA = NAN;
   MDAL_G_minimumMaximum( g, &minE, &maxE );
   MDAL_G_minimumMaximumApprox( g, 3, &minA, &maxA );
 
-  EXPECT_DOUBLE_EQ( 1000.0, maxE );      // exact captures the outlier
-  EXPECT_LT( maxA, 1000.0 );             // approximate misses it
+  EXPECT_DOUBLE_EQ( kPeakValue, maxE );  // exact captures the outlier
+  EXPECT_LT( maxA, kPeakValue );         // approximate misses it
   EXPECT_LE( minE, minA );               // approximate range is contained in exact range
   EXPECT_GE( maxE, maxA );
 
@@ -128,21 +134,21 @@ TEST( MeshApproxStatisticsTest, SampleCountThreeMissesMiddleOutlier )
 TEST( MeshApproxStatisticsTest, ExactCacheUntouchedAfterApproximate )
 {
   std::string file = tmp_file( "/approx_stats_cache.slf" );
-  MDAL_MeshH m = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  MDAL_MeshH m = buildMultiTimestepMesh( file );
   ASSERT_NE( m, nullptr );
 
-  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  MDAL_DatasetGroupH g = lastGroup( m );
   ASSERT_NE( g, nullptr );
 
   // Call approximate first
   double minA = NAN, maxA = NAN;
   MDAL_G_minimumMaximumApprox( g, 3, &minA, &maxA );
-  EXPECT_LT( maxA, 1000.0 );
+  EXPECT_LT( maxA, kPeakValue );
 
   // Exact must still return the true range
   double minE = NAN, maxE = NAN;
   MDAL_G_minimumMaximum( g, &minE, &maxE );
-  EXPECT_DOUBLE_EQ( 1000.0, maxE );
+  EXPECT_DOUBLE_EQ( kPeakValue, maxE );
 
   MDAL_CloseMesh( m );
 }
@@ -152,7 +158,7 @@ TEST( MeshLoadFlagsTest, SkipStatisticsThenLazyExact )
   // Build a multi-timestep selafin first (writes through the addDataset edit
   // mode path, which always computes stats — eager path is unaffected).
   std::string file = tmp_file( "/skipstats_eager.slf" );
-  MDAL_MeshH eager = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  MDAL_MeshH eager = buildMultiTimestepMesh( file );
   ASSERT_NE( eager, nullptr );
   MDAL_CloseMesh( eager );
 
@@ -161,23 +167,21 @@ TEST( MeshLoadFlagsTest, SkipStatisticsThenLazyExact )
   MDAL_MeshH m = MDAL_LoadMeshWithFlags( file.c_str(), MDAL_LF_SkipStatistics );
   ASSERT_NE( m, nullptr );
 
-  // Expect at least one dataset group.
   ASSERT_GE( MDAL_M_datasetGroupCount( m ), 1 );
-  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  MDAL_DatasetGroupH g = lastGroup( m );
   ASSERT_NE( g, nullptr );
 
-  // Approximate min/max computes only on a sample of timesteps; result must
-  // still be contained within the (later-computed) exact range and the
-  // outlier dataset (idx 5) is missed when sampleCount=3.
+  // Approximate min/max computes only on a sample of timesteps; the outlier
+  // dataset (index 5) is missed when sampleCount=3.
   double minA = NAN, maxA = NAN;
   MDAL_G_minimumMaximumApprox( g, 3, &minA, &maxA );
   EXPECT_FALSE( std::isnan( maxA ) );
-  EXPECT_LT( maxA, 1000.0 );
+  EXPECT_LT( maxA, kPeakValue );
 
-  // Exact (lazy) computes on first access and caches: must return 1000.
+  // Exact (lazy) computes on first access and caches: must return the outlier.
   double minE = NAN, maxE = NAN;
   MDAL_G_minimumMaximum( g, &minE, &maxE );
-  EXPECT_DOUBLE_EQ( 1000.0, maxE );
+  EXPECT_DOUBLE_EQ( kPeakValue, maxE );
 
   // A second exact call returns the cached value (sanity).
   double minE2 = NAN, maxE2 = NAN;
@@ -190,23 +194,54 @@ TEST( MeshLoadFlagsTest, SkipStatisticsThenLazyExact )
 
 TEST( MeshLoadFlagsTest, NoSkipFlagPreservesEagerBehavior )
 {
-  // Without the flag, MDAL_LoadMesh and MDAL_LoadMeshWithFlags(uri, 0) must
-  // compute stats eagerly so the first MDAL_G_minimumMaximum call is a
-  // no-op cache read.
+  // Without the flag, MDAL_LoadMeshWithFlags(uri, 0) must behave exactly
+  // like MDAL_LoadMesh.
   std::string file = tmp_file( "/skipstats_default.slf" );
-  MDAL_MeshH eager = buildMultiTimestepMesh( file, 10, 5, 1000.0 );
+  MDAL_MeshH eager = buildMultiTimestepMesh( file );
   ASSERT_NE( eager, nullptr );
   MDAL_CloseMesh( eager );
 
   MDAL_MeshH m = MDAL_LoadMeshWithFlags( file.c_str(), 0 );
   ASSERT_NE( m, nullptr );
 
-  MDAL_DatasetGroupH g = MDAL_M_datasetGroup( m, MDAL_M_datasetGroupCount( m ) - 1 );
+  MDAL_DatasetGroupH g = lastGroup( m );
   ASSERT_NE( g, nullptr );
 
   double min = NAN, max = NAN;
   MDAL_G_minimumMaximum( g, &min, &max );
-  EXPECT_DOUBLE_EQ( 1000.0, max );
+  EXPECT_DOUBLE_EQ( kPeakValue, max );
+
+  MDAL_CloseMesh( m );
+}
+
+TEST( MeshLoadFlagsTest, LoadDatasetsWithFlagsSkipsStatistics )
+{
+  // Attach the SELAFIN file as a dataset file onto an already-loaded mesh:
+  // MDAL_M_LoadDatasetsWithFlags must honor MDAL_LF_SkipStatistics too.
+  std::string file = tmp_file( "/skipstats_loaddatasets.slf" );
+  MDAL_MeshH built = buildMultiTimestepMesh( file );
+  ASSERT_NE( built, nullptr );
+  MDAL_CloseMesh( built );
+
+  MDAL_MeshH m = MDAL_LoadMeshWithFlags( file.c_str(), MDAL_LF_SkipStatistics );
+  ASSERT_NE( m, nullptr );
+  const int groupsBefore = MDAL_M_datasetGroupCount( m );
+
+  MDAL_M_LoadDatasetsWithFlags( m, file.c_str(), MDAL_LF_SkipStatistics );
+  EXPECT_EQ( MDAL_LastStatus(), MDAL_Status::None );
+  ASSERT_GT( MDAL_M_datasetGroupCount( m ), groupsBefore );
+
+  MDAL_DatasetGroupH g = lastGroup( m );
+  ASSERT_NE( g, nullptr );
+
+  double minA = NAN, maxA = NAN;
+  MDAL_G_minimumMaximumApprox( g, 3, &minA, &maxA );
+  EXPECT_FALSE( std::isnan( maxA ) );
+  EXPECT_LT( maxA, kPeakValue );
+
+  double minE = NAN, maxE = NAN;
+  MDAL_G_minimumMaximum( g, &minE, &maxE );
+  EXPECT_DOUBLE_EQ( kPeakValue, maxE );
 
   MDAL_CloseMesh( m );
 }


### PR DESCRIPTION
Lets callers opt out of the eager per-dataset statistics scan during MDAL_LoadMesh, dramatically reducing load time for large multi-timestep meshes when an exact min/max is not required upfront.

The gain is substantial!
I tested a "small" SELAFIN result file. We can have bigger ones which freeze QGIS for several minutes...

Fixes #526 

Tested on QGIS with improvements to use this new API. Mesh file is stored on USB3 drive stick. I don't have access to network shared drive for now. My hardware is pretty old (i7-4790, 8Gb RAM).

<details>
  <summary>Python snippet</summary>
  
  ```python
from qgis.core import QgsMeshLayer, QgsProject, QgsSettings
from time import perf_counter

MESH_PATH = "/media/nicogodet/Nouveau nom/v5.res"
SAMPLE_COUNT = 10

s = QgsSettings()
key_on = "mesh/approximate-min-max-on-load"
key_n  = "mesh/approximate-min-max-sample-count"

def load_and_inspect(label):
    t0 = perf_counter()
    layer = QgsMeshLayer(MESH_PATH, f"v5_{label}", "mdal")
    elapsed = perf_counter() - t0
    if not layer.isValid():
        print(f"[{label}] invalid layer")
        return None, elapsed
    QgsProject.instance().addMapLayer(layer)

    provider = layer.dataProvider()
    n_groups = layer.datasetGroupCount()
    print(f"\n[{label}] load: {elapsed:.3f} s   groups: {n_groups}")
    print(f"  {'#':>3}  {'name':<32}  {'kind':<7}  {'ts':>6}  {'min':>14}  {'max':>14}")
    for g in range(n_groups):
        meta = provider.datasetGroupMetadata(g)
        n_ts = provider.datasetCount(g)
        kind = "scalar" if meta.isScalar() else "vector"
        print(f"  {g:>3}  {meta.name()[:32]:<32}  {kind:<7}  {n_ts:>6}  {meta.minimum():>14.6g}  {meta.maximum():>14.6g}")
    return layer, elapsed

# --- exact (toggle off) ---
s.setValue(key_on, False)
s.setValue(key_n, SAMPLE_COUNT)
QgsProject.instance().removeAllMapLayers()
_, t_exact = load_and_inspect("exact")

# --- approx (toggle on) ---
s.setValue(key_on, True)
QgsProject.instance().removeAllMapLayers()
_, t_approx = load_and_inspect(f"approx-{SAMPLE_COUNT}")

# --- résumé ---
print(f"\n>>> exact:                 {t_exact:.3f} s")
print(f">>> approx ({SAMPLE_COUNT} timesteps):   {t_approx:.3f} s")
print(f">>> speedup: x{t_exact / t_approx:.1f}  ({t_exact - t_approx:+.3f} s saved)")

  ```
  
</details>

Results

```console
[exact] load: 44.877 s   groups: 7
    #  name                              kind         ts             min             max
    0  vitesse       ms                  vector      507               0         5.56107
    1  hauteur d'eau   m                 scalar      507               0          26.833
    2  surface libre   m                 scalar      507           -8.88           68.45
    3  fond            m                 scalar      507           -8.88           68.45
    4  frottement                        scalar      507               6              50
    5  cote maximum    m                 scalar      507           -8.88           68.45
    6  vitesse maximum ms                scalar      507               0         21.0616

[approx-10] load: 2.296 s   groups: 7
    #  name                              kind         ts             min             max
    0  vitesse       ms                  vector      507               0           3.911
    1  hauteur d'eau   m                 scalar      507               0          26.833
    2  surface libre   m                 scalar      507           -8.88           68.45
    3  fond            m                 scalar      507           -8.88           68.45
    4  frottement                        scalar      507               6              50
    5  cote maximum    m                 scalar      507           -8.88           68.45
    6  vitesse maximum ms                scalar      507               0         21.0616

exact:                 44.877 s
approx (10 timesteps):   2.296 s
speedup: x19.5  (+42.581 s saved)
``` 

## AI disclaimer

Claude code (mostly Opus 5 and reviewed by Fable 5.1) done most of the work. I wrote the specifications (look at what GDAL does for rasters, dig in QGIS code base to learn the load path of rasters and meshes then look at MDAL to implement a similar approximative stats as GDAL does), Claude did the work. I did not reviewed all the changes but I read a bit to correct some comments and reduce verbosity.