### PR TITLE
Fix doc build on newer Python/Sphinx environments

### DIFF
--- a/docs/.azure-pipelines.yml
+++ b/docs/.azure-pipelines.yml
@@ -20,7 +20,7 @@ variables:
 jobs:
   - job: 'Documentation'
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-22.04'
     container:
       image: osgeo/proj-docs
       options: --privileged

--- a/docs/source/_extensions/driverproperties.py
+++ b/docs/source/_extensions/driverproperties.py
@@ -70,6 +70,7 @@ class shortname(nodes.Admonition, nodes.Element):
 def visit_shortname_node(self, node):
     self.body.append(self.starttag(
             node, 'div', CLASS=('admonition shortname')))
+    self.context.append('</div>\n')
 
 class built_in_by_default(nodes.Admonition, nodes.Element):
     pass
@@ -77,6 +78,7 @@ class built_in_by_default(nodes.Admonition, nodes.Element):
 def visit_built_in_by_default_node(self, node):
     self.body.append(self.starttag(
             node, 'div', CLASS=('admonition built_in_by_default')))
+    self.context.append('</div>\n')
 
 class build_dependencies(nodes.Admonition, nodes.Element):
     pass
@@ -84,6 +86,7 @@ class build_dependencies(nodes.Admonition, nodes.Element):
 def visit_build_dependencies_node(self, node):
     self.body.append(self.starttag(
             node, 'div', CLASS=('admonition build_dependencies')))
+    self.context.append('</div>\n')
 
 class supports_create(nodes.Admonition, nodes.Element):
     pass
@@ -91,6 +94,7 @@ class supports_create(nodes.Admonition, nodes.Element):
 def visit_supports_create_node(self, node):
     self.body.append(self.starttag(
             node, 'div', CLASS=('admonition supports_create')))
+    self.context.append('</div>\n')
 
 class supports_createcopy(nodes.Admonition, nodes.Element):
     pass
@@ -98,6 +102,7 @@ class supports_createcopy(nodes.Admonition, nodes.Element):
 def visit_supports_createcopy_node(self, node):
     self.body.append(self.starttag(
             node, 'div', CLASS=('admonition supports_createcopy')))
+    self.context.append('</div>\n')
 
 class supports_virtualio(nodes.Admonition, nodes.Element):
     pass
@@ -105,6 +110,7 @@ class supports_virtualio(nodes.Admonition, nodes.Element):
 def visit_supports_georeferencing_node(self, node):
     self.body.append(self.starttag(
             node, 'div', CLASS=('admonition supports_georeferencing')))
+    self.context.append('</div>\n')
 
 class supports_georeferencing(nodes.Admonition, nodes.Element):
     pass
@@ -112,6 +118,7 @@ class supports_georeferencing(nodes.Admonition, nodes.Element):
 def visit_supports_virtualio_node(self, node):
     self.body.append(self.starttag(
             node, 'div', CLASS=('admonition supports_virtualio')))
+    self.context.append('</div>\n')
 
 
 from docutils.parsers.rst import Directive

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,7 +126,7 @@ latex_elements = {
 
 # Additional stuff for the LaTeX preamble.
 'preamble': preamble,
-'inputenc':'\\usepackage[utf8]{inputenc}\n\\usepackage{CJKutf8}\n\\usepackage{substitutefont}',
+'inputenc':'\\usepackage[utf8]{inputenc}\n\\usepackage{CJKutf8}',
 'babel':'\\usepackage[russian,main=english]{babel}\n\\selectlanguage{english}',
 'fontenc':'\\usepackage[LGR,X2,T1]{fontenc}'
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,7 +62,6 @@ html_theme_options = {
     'canonical_url': 'https://mdal.xyz',
     'analytics_id': '',  #  Provided by Google in your dashboard
     'logo_only': True,
-    'display_version': True,
     'prev_next_buttons_location': 'both',
     'style_external_links': False,
     #'vcs_pageview_mode': '',


### PR DESCRIPTION
## Summary

Fixes the documentation build which fails on current CI due to outdated Ubuntu image and incompatibilities with newer versions of Sphinx and sphinx-rtd-theme:

- Update Azure Pipelines docs image from ubuntu-16.04 to ubuntu-22.04
- Fix Sphinx crash on newer versions caused by missing `context.append` in custom admonition visitors
- Remove `display_version` from sphinx-rtd-theme options (no longer supported)
- Remove `substitutefont` from LaTeX config (no longer supported)

These changes are prerequisites for the doc build CI to pass on the SWW driver PR (#529).

🤖 Generated with [Claude Code](https://claude.com/claude-code)