### PR TITLE
Fix mac ci

### DIFF
--- a/.github/workflows/osx_tests.yml
+++ b/.github/workflows/osx_tests.yml
@@ -3,8 +3,39 @@ on: [push, pull_request]
 env:
   QGIS_DEPS_VERSION: 0.4.0
 jobs:
-  osx_tests:
-    runs-on: macos-13
+  osx_tests_arm64:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout MDAL
+        uses: actions/checkout@v4
+
+      - name: install deps
+        run: |
+          brew install gdal hdf5 netcdf libxml2 sqlite
+          gdalinfo --formats
+
+      - name: build MDAL
+        run: |
+          mkdir -p ../build_osx
+          cd ../build_osx
+          cmake \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_PREFIX_PATH="$(brew --prefix);$(brew --prefix libxml2);$(brew --prefix sqlite)" \
+              -DNETCDF_PREFIX=$(brew --prefix netcdf) \
+              -DSQLITE3_INCLUDE_DIR=$(brew --prefix sqlite)/include \
+              -DSQLITE3_LIBRARY=$(brew --prefix sqlite)/lib/libsqlite3.dylib \
+              ../MDAL
+          make -j$(sysctl -n hw.ncpu)
+
+      - name: Run tests
+        env:
+          CTEST_TARGET_SYSTEM: Linux-gcc
+        run: |
+          cd ../build_osx
+          ctest -VV
+
+  osx_tests_intel:
+    runs-on: macos-15-intel
     steps:
       - name: Checkout MDAL
         uses: actions/checkout@v4
@@ -35,7 +66,7 @@ jobs:
               -DLIBXML2_INCLUDE_DIR=/opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION}/stage/include \
               -DLIBXML2_LIBRARY=/opt/QGIS/qgis-deps-${QGIS_DEPS_VERSION}/stage/lib/libxml2.dylib \
               ../MDAL
-          make -j`nproc`
+          make -j$(sysctl -n hw.ncpu)
 
       - name: Run tests
         env:

--- a/.github/workflows/osx_tests.yml
+++ b/.github/workflows/osx_tests.yml
@@ -34,13 +34,6 @@ jobs:
           cd ../build_osx
           ctest -VV
 
-      - name: Report failed tests
-        if: failure()
-        run: |
-          cd ../build_osx
-          echo "::error::Failed tests: $(paste -sd, Testing/Temporary/LastTestsFailed.log)"
-          grep -B1 -A4 "Failure\|FAILED\|Subprocess" Testing/Temporary/LastTest.log | tail -60 | while IFS= read -r line; do echo "::error::$line"; done
-
   osx_tests_intel:
     runs-on: macos-15-intel
     steps:

--- a/.github/workflows/osx_tests.yml
+++ b/.github/workflows/osx_tests.yml
@@ -39,7 +39,6 @@ jobs:
         run: |
           cd ../build_osx
           echo "::error::Failed tests: $(paste -sd, Testing/Temporary/LastTestsFailed.log)"
-          grep "^DIAG" Testing/Temporary/LastTest.log | while IFS= read -r line; do echo "::error::$line"; done
           grep -B1 -A4 "Failure\|FAILED\|Subprocess" Testing/Temporary/LastTest.log | tail -60 | while IFS= read -r line; do echo "::error::$line"; done
 
   osx_tests_intel:

--- a/.github/workflows/osx_tests.yml
+++ b/.github/workflows/osx_tests.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           cd ../build_osx
           echo "::error::Failed tests: $(paste -sd, Testing/Temporary/LastTestsFailed.log)"
+          grep "^DIAG" Testing/Temporary/LastTest.log | while IFS= read -r line; do echo "::error::$line"; done
           grep -B1 -A4 "Failure\|FAILED\|Subprocess" Testing/Temporary/LastTest.log | tail -60 | while IFS= read -r line; do echo "::error::$line"; done
 
   osx_tests_intel:

--- a/.github/workflows/osx_tests.yml
+++ b/.github/workflows/osx_tests.yml
@@ -34,6 +34,13 @@ jobs:
           cd ../build_osx
           ctest -VV
 
+      - name: Report failed tests
+        if: failure()
+        run: |
+          cd ../build_osx
+          echo "::error::Failed tests: $(paste -sd, Testing/Temporary/LastTestsFailed.log)"
+          grep -B1 -A4 "Failure\|FAILED\|Subprocess" Testing/Temporary/LastTest.log | tail -60 | while IFS= read -r line; do echo "::error::$line"; done
+
   osx_tests_intel:
     runs-on: macos-15-intel
     steps:

--- a/.github/workflows/osx_tests.yml
+++ b/.github/workflows/osx_tests.yml
@@ -4,7 +4,7 @@ env:
   QGIS_DEPS_VERSION: 0.4.0
 jobs:
   osx_tests_arm64:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout MDAL
         uses: actions/checkout@v4

--- a/mdal/frmts/mdal_hec2d.cpp
+++ b/mdal/frmts/mdal_hec2d.cpp
@@ -325,7 +325,10 @@ void MDAL::DriverHec2D::readFaceOutput( const HdfFile &hdfFile,
           double ny2 =  dx2 / l2;
 
           double deter = nx1 * ny2 - nx2 * ny1;
-          if ( deter == 0 ) //colinear face, forbidden by hecras, but better to prevent
+          // (nearly) colinear faces make the system ill-conditioned; an exact-zero test
+          // is not enough because FMA contraction (e.g. on arm64) leaves a tiny nonzero
+          // residual for exactly parallel normals
+          if ( std::fabs( deter ) < 1e-8 )
             continue;
           valx += ( ny2 * val1 - ny1 * val2 ) / deter;
           valy += ( nx1 * val2 - nx2 * val1 ) / deter;

--- a/mdal/frmts/mdal_hec2d.cpp
+++ b/mdal/frmts/mdal_hec2d.cpp
@@ -325,9 +325,10 @@ void MDAL::DriverHec2D::readFaceOutput( const HdfFile &hdfFile,
           double ny2 =  dx2 / l2;
 
           double deter = nx1 * ny2 - nx2 * ny1;
-          // (nearly) colinear faces make the system ill-conditioned; an exact-zero test
-          // is not enough because FMA contraction (e.g. on arm64) leaves a tiny nonzero
-          // residual for exactly parallel normals
+          // (nearly) colinear faces, forbidden by hecras, but better to prevent:
+          // they make the system ill-conditioned, and an exact-zero test is not enough
+          // because FMA contraction (e.g. on arm64) leaves a tiny nonzero residual
+          // for exactly parallel normals
           if ( std::fabs( deter ) < 1e-8 )
             continue;
           valx += ( ny2 * val1 - ny1 * val2 ) / deter;

--- a/tests/test_hec2d.cpp
+++ b/tests/test_hec2d.cpp
@@ -179,7 +179,6 @@ TEST( MeshHec2dTest, simpleArea )
   EXPECT_TRUE( MDAL::equals( 0.0001003014, value, 0.00000001 ) );
 
   MDAL_D_minimumMaximum( ds, &min, &max );
-  printf( "DIAG hec2d velocity ds35 min=%.17g max=%.17g\n", min, max );
   EXPECT_TRUE( MDAL::equals( 7.3807e-5, min, 0.000001 ) );
   EXPECT_TRUE( MDAL::equals( 0.0452122, max, 0.000001 ) );
 

--- a/tests/test_hec2d.cpp
+++ b/tests/test_hec2d.cpp
@@ -179,6 +179,7 @@ TEST( MeshHec2dTest, simpleArea )
   EXPECT_TRUE( MDAL::equals( 0.0001003014, value, 0.00000001 ) );
 
   MDAL_D_minimumMaximum( ds, &min, &max );
+  printf( "DIAG hec2d velocity ds35 min=%.17g max=%.17g\n", min, max );
   EXPECT_TRUE( MDAL::equals( 7.3807e-5, min, 0.000001 ) );
   EXPECT_TRUE( MDAL::equals( 0.0452122, max, 0.000001 ) );
 


### PR DESCRIPTION
Fixes the macos workflow.
`macos-13` runners are retired, so replaced the existing job to use `macos-15-intel` instead, which shall live until late 2027.
A new `osx_tests_arm64` job was added using `macos-latest`.

This surfaced an issue with a test due to cpu arch change which is also fixed.